### PR TITLE
Smooth difficulty ramp and shrink tail growth

### DIFF
--- a/flyin nyan/index.html
+++ b/flyin nyan/index.html
@@ -181,14 +181,14 @@
             playerImage.src = 'assets/player.png';
 
             const config = {
-                baseGameSpeed: 180,
+                baseGameSpeed: 160,
                 speedGrowth: 6,
                 obstacleSpawnInterval: 950,
                 collectibleSpawnInterval: 1400,
                 powerUpSpawnInterval: 11000,
                 trailSpacing: 18,
                 baseTrailLength: 20,
-                trailGrowthPerStreak: 4,
+                trailGrowthPerStreak: 0.4,
                 tailSmoothing: {
                     growth: 32,
                     shrink: 64
@@ -196,6 +196,15 @@
                 comboDecayWindow: 3200,
                 projectileCooldown: 200,
                 projectileSpeed: 900,
+                difficulty: {
+                    rampDuration: 60000,
+                    speedRamp: { start: 0.35, end: 1.05 },
+                    spawnIntensity: {
+                        obstacle: { start: 0.45, end: 1.15 },
+                        collectible: { start: 0.6, end: 0.95 },
+                        powerUp: { start: 0.5, end: 0.85 }
+                    }
+                },
                 player: {
                     width: 120,
                     height: 120,
@@ -248,6 +257,7 @@
                 gameSpeed: config.baseGameSpeed,
                 timeSinceLastShot: 0,
                 gameState: 'ready',
+                elapsedTime: 0,
                 powerUpTimers: {
                     superSpeed: 0,
                     bulletSpread: 0,
@@ -300,6 +310,7 @@
                 state.comboTimer = 0;
                 state.gameSpeed = config.baseGameSpeed;
                 state.timeSinceLastShot = 0;
+                state.elapsedTime = 0;
                 state.powerUpTimers.superSpeed = 0;
                 state.powerUpTimers.bulletSpread = 0;
                 state.powerUpTimers.missiles = 0;
@@ -336,6 +347,32 @@
 
             function clamp(value, min, max) {
                 return Math.max(min, Math.min(max, value));
+            }
+
+            function lerp(a, b, t) {
+                return a + (b - a) * t;
+            }
+
+            function easeInOutQuad(t) {
+                return t < 0.5 ? 2 * t * t : 1 - Math.pow(-2 * t + 2, 2) / 2;
+            }
+
+            function getDifficultyProgress() {
+                if (!config.difficulty) return 1;
+                return clamp(state.elapsedTime / config.difficulty.rampDuration, 0, 1);
+            }
+
+            function getSpeedRampMultiplier() {
+                if (!config.difficulty?.speedRamp) return 1;
+                const eased = easeInOutQuad(getDifficultyProgress());
+                return lerp(config.difficulty.speedRamp.start, config.difficulty.speedRamp.end, eased);
+            }
+
+            function getSpawnIntensity(type) {
+                const settings = config.difficulty?.spawnIntensity?.[type];
+                if (!settings) return 1;
+                const eased = easeInOutQuad(getDifficultyProgress());
+                return lerp(settings.start, settings.end, eased);
             }
 
             function showOverlay(message, buttonText) {
@@ -706,9 +743,9 @@
                 spawnTimers.collectible += delta;
                 spawnTimers.powerUp += delta;
 
-                const obstacleInterval = config.obstacleSpawnInterval / (1 + state.gameSpeed * 0.005);
-                const collectibleInterval = config.collectibleSpawnInterval / (1 + state.gameSpeed * 0.004);
-                const powerUpInterval = config.powerUpSpawnInterval / (1 + state.gameSpeed * 0.003);
+                const obstacleInterval = config.obstacleSpawnInterval / (1 + state.gameSpeed * 0.005 * getSpawnIntensity('obstacle'));
+                const collectibleInterval = config.collectibleSpawnInterval / (1 + state.gameSpeed * 0.004 * getSpawnIntensity('collectible'));
+                const powerUpInterval = config.powerUpSpawnInterval / (1 + state.gameSpeed * 0.003 * getSpawnIntensity('powerUp'));
 
                 if (spawnTimers.obstacle >= obstacleInterval) {
                     spawnTimers.obstacle = 0;
@@ -1043,7 +1080,8 @@
                 lastTime = timestamp;
 
                 if (state.gameState === 'running') {
-                    state.gameSpeed += config.speedGrowth * (delta / 1000);
+                    state.elapsedTime += delta;
+                    state.gameSpeed += config.speedGrowth * getSpeedRampMultiplier() * (delta / 1000);
 
                     updatePlayer(delta);
                     updateProjectiles(delta);


### PR DESCRIPTION
## Summary
- reduce the rainbow tail growth per streak by 90% so streaks feel manageable
- introduce an eased difficulty ramp that slowly increases speed and spawn intensity over the first minute
- retune spawn interval math and base speed for a smoother onboarding experience

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68ca377df2ec8324936a6998fdfe46f8