### PR TITLE
Use logo image during loading

### DIFF
--- a/flyin nyan/index.html
+++ b/flyin nyan/index.html
@@ -214,7 +214,7 @@
 </head>
 <body>
     <div id="loadingScreen">
-        <img src="loading.png" alt="Cyborg boot sequence" id="loadingImage">
+        <img src="logo.png" alt="Cyborg boot sequence" id="loadingImage">
         <div id="loadingStatus">
             <span class="loading-prefix">[SYS-BOOT:00]</span>
             <span class="loading-line">Initializing quantum cores — <span class="loading-percent">000%</span></span>


### PR DESCRIPTION
## Summary
- replace the loading screen image reference to use `logo.png` so the logo displays during initialization

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68ca613885b48324bf937f3b13b0d49f