### PR TITLE
Add background image styling to loading screen

### DIFF
--- a/flyin nyan/index.html
+++ b/flyin nyan/index.html
@@ -34,7 +34,9 @@
             justify-content: center;
             align-items: center;
             gap: 28px;
-            background: #fff;
+            background:
+                linear-gradient(rgba(15, 23, 42, 0.82), rgba(15, 23, 42, 0.82)),
+                url('background.png') center / cover no-repeat;
             z-index: 999;
             transition: opacity 400ms ease;
         }


### PR DESCRIPTION
## Summary
- update the loading screen styling to use a full-screen background image with a dark overlay so it covers the viewport

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cae06553788324b1f7227b0d69f0e6