### PR TITLE
Add survival timer and persistent high score tracking

### DIFF
--- a/flyin nyan/index.html
+++ b/flyin nyan/index.html
@@ -121,6 +121,26 @@
             z-index: 1;
         }
 
+        #survivalTimer {
+            position: absolute;
+            top: 12px;
+            left: 50%;
+            transform: translateX(-50%);
+            font-size: 16px;
+            font-weight: 600;
+            letter-spacing: 0.04em;
+            padding: 6px 16px;
+            border-radius: 999px;
+            background: rgba(15, 23, 42, 0.7);
+            box-shadow: 0 6px 18px rgba(0, 0, 0, 0.35);
+            text-shadow: 0 0 6px rgba(0, 0, 0, 0.35);
+            z-index: 2;
+        }
+
+        #survivalTimer .value {
+            color: #7dd3fc;
+        }
+
         #stats span.value {
             font-weight: 700;
             color: #ffd54f;
@@ -173,6 +193,7 @@
             font-size: 1rem;
             max-width: 360px;
             color: rgba(255, 255, 255, 0.82);
+            white-space: pre-line;
         }
 
         #overlay button {
@@ -212,6 +233,53 @@
             background: linear-gradient(90deg, #6a5acd, #00e5ff);
             transition: width 100ms ease-out;
         }
+
+        #highScorePanel {
+            margin-top: 8px;
+            padding: 12px 18px;
+            border-radius: 12px;
+            background: rgba(12, 15, 35, 0.6);
+            box-shadow: inset 0 0 0 1px rgba(148, 163, 184, 0.18);
+            text-align: left;
+            max-width: 320px;
+        }
+
+        #highScoreTitle {
+            font-size: 0.85rem;
+            text-transform: uppercase;
+            letter-spacing: 0.18em;
+            margin-bottom: 8px;
+            color: rgba(148, 163, 184, 0.95);
+        }
+
+        #highScoreList {
+            list-style: decimal inside;
+            margin: 0;
+            padding: 0;
+            display: flex;
+            flex-direction: column;
+            gap: 6px;
+            font-size: 0.9rem;
+        }
+
+        #highScoreList li {
+            color: rgba(226, 232, 240, 0.92);
+        }
+
+        #highScoreList li.empty {
+            list-style: none;
+            color: rgba(148, 163, 184, 0.85);
+            font-style: italic;
+        }
+
+        #highScoreList li .time {
+            font-weight: 600;
+            color: #7dd3fc;
+        }
+
+        #highScoreList li .score {
+            color: #facc15;
+        }
     </style>
 </head>
 <body>
@@ -227,6 +295,7 @@
         <div class="backgroundLayer" id="backgroundLayerB"></div>
     </div>
     <canvas id="gameCanvas" width="900" height="600"></canvas>
+    <div id="survivalTimer">Survival: <span class="value" id="timerValue">00:00.0</span></div>
     <div id="stats">
         Score: <span class="value" id="score">0</span><br>
         NYAN: <span class="value" id="nyan">0</span><br>
@@ -251,6 +320,10 @@
         <h1>NYAN ESCAPE</h1>
         <p id="overlayMessage">Thread the cosmic needle, gather NYAN, and charge Nova Pulses to vaporize space junk. Ready to glide?</p>
         <button id="overlayButton">Start Flight</button>
+        <div id="highScorePanel">
+            <div id="highScoreTitle">Top Flight Times</div>
+            <ol id="highScoreList"></ol>
+        </div>
     </div>
 
     <script>
@@ -285,6 +358,152 @@
             const overlayButton = document.getElementById('overlayButton');
             const loadingScreen = document.getElementById('loadingScreen');
             const loadingStatus = document.getElementById('loadingStatus');
+            const timerValueEl = document.getElementById('timerValue');
+            const highScoreListEl = document.getElementById('highScoreList');
+            const highScoreTitleEl = document.getElementById('highScoreTitle');
+
+            const STORAGE_KEYS = {
+                playerName: 'nyanEscape.playerName',
+                highScores: 'nyanEscape.highScores'
+            };
+
+            let storageAvailable = false;
+            try {
+                const testKey = '__nyanEscapeTest__';
+                localStorage.setItem(testKey, '1');
+                localStorage.removeItem(testKey);
+                storageAvailable = true;
+            } catch (error) {
+                storageAvailable = false;
+            }
+
+            function readStorage(key) {
+                if (!storageAvailable) return null;
+                try {
+                    return localStorage.getItem(key);
+                } catch (error) {
+                    storageAvailable = false;
+                    return null;
+                }
+            }
+
+            function writeStorage(key, value) {
+                if (!storageAvailable) return;
+                try {
+                    localStorage.setItem(key, value);
+                } catch (error) {
+                    storageAvailable = false;
+                }
+            }
+
+            function loadHighScores() {
+                const raw = readStorage(STORAGE_KEYS.highScores);
+                if (!raw) return {};
+                try {
+                    const parsed = JSON.parse(raw);
+                    return typeof parsed === 'object' && parsed !== null ? parsed : {};
+                } catch (error) {
+                    return {};
+                }
+            }
+
+            function persistHighScores(data) {
+                if (!storageAvailable) return;
+                writeStorage(STORAGE_KEYS.highScores, JSON.stringify(data));
+            }
+
+            function requestPlayerName() {
+                const defaultName = 'Ace Pilot';
+                const storedName = readStorage(STORAGE_KEYS.playerName);
+                if (storedName) {
+                    return storedName;
+                }
+                const canPrompt = typeof prompt === 'function';
+                const prompted = canPrompt ? prompt('Choose your pilot callsign to track high scores:', defaultName) : null;
+                const name = (prompted ?? '').trim() || defaultName;
+                writeStorage(STORAGE_KEYS.playerName, name);
+                return name;
+            }
+
+            let highScoreData = loadHighScores();
+            let playerName = requestPlayerName();
+
+            function formatTime(milliseconds) {
+                const totalSeconds = Math.floor(milliseconds / 1000);
+                const minutes = Math.floor(totalSeconds / 60);
+                const seconds = totalSeconds % 60;
+                const tenths = Math.floor((milliseconds % 1000) / 100);
+                return `${String(minutes).padStart(2, '0')}:${String(seconds).padStart(2, '0')}.${tenths}`;
+            }
+
+            function updateTimerDisplay() {
+                if (!timerValueEl) return;
+                timerValueEl.textContent = formatTime(state.elapsedTime);
+            }
+
+            function recordHighScore(durationMs, score) {
+                if (!playerName || durationMs <= 0) return;
+                const entry = {
+                    timeMs: durationMs,
+                    score,
+                    recordedAt: Date.now()
+                };
+                const userScores = highScoreData[playerName] ? [...highScoreData[playerName]] : [];
+                userScores.push(entry);
+                userScores.sort((a, b) => {
+                    if (b.timeMs !== a.timeMs) return b.timeMs - a.timeMs;
+                    if (b.score !== a.score) return b.score - a.score;
+                    return b.recordedAt - a.recordedAt;
+                });
+                highScoreData[playerName] = userScores.slice(0, 3);
+                persistHighScores(highScoreData);
+            }
+
+            function updateHighScorePanel() {
+                if (!highScoreListEl || !highScoreTitleEl) return;
+                highScoreTitleEl.textContent = `Top Flight Times — ${playerName}`;
+                highScoreListEl.innerHTML = '';
+                const entries = highScoreData[playerName] ?? [];
+                if (!entries.length) {
+                    const emptyItem = document.createElement('li');
+                    emptyItem.className = 'empty';
+                    emptyItem.textContent = 'No recorded runs yet. Survive to set a record!';
+                    highScoreListEl.appendChild(emptyItem);
+                    return;
+                }
+                for (const entry of entries) {
+                    const item = document.createElement('li');
+                    const timeSpan = document.createElement('span');
+                    timeSpan.className = 'time';
+                    timeSpan.textContent = formatTime(entry.timeMs);
+                    const scoreSpan = document.createElement('span');
+                    scoreSpan.className = 'score';
+                    scoreSpan.textContent = ` — ${entry.score.toLocaleString()} pts`;
+                    item.appendChild(timeSpan);
+                    item.appendChild(scoreSpan);
+                    highScoreListEl.appendChild(item);
+                }
+            }
+
+            updateHighScorePanel();
+
+            if (highScoreTitleEl && typeof highScoreTitleEl.addEventListener === 'function') {
+                highScoreTitleEl.addEventListener('click', () => {
+                    if (typeof prompt !== 'function') return;
+                    const nextName = prompt('Update your pilot callsign:', playerName);
+                    const trimmed = (nextName ?? '').trim();
+                    if (!trimmed || trimmed === playerName) {
+                        return;
+                    }
+                    playerName = trimmed;
+                    writeStorage(STORAGE_KEYS.playerName, playerName);
+                    if (!highScoreData[playerName]) {
+                        highScoreData[playerName] = [];
+                    }
+                    persistHighScores(highScoreData);
+                    updateHighScorePanel();
+                });
+            }
 
             function runCyborgLoadingSequence() {
                 if (!loadingScreen || !loadingStatus) {
@@ -503,6 +722,8 @@
                 recentVillains: []
             };
 
+            updateTimerDisplay();
+
             const keys = new Set();
             const projectiles = [];
             const obstacles = [];
@@ -700,6 +921,7 @@
                 createInitialStars();
                 comboFillEl.style.width = '100%';
                 updateHUD();
+                updateTimerDisplay();
             }
 
             function createInitialStars() {
@@ -1506,7 +1728,12 @@
             function triggerGameOver(message) {
                 if (state.gameState !== 'running') return;
                 state.gameState = 'gameover';
-                showOverlay(`${message}\nFinal Score: ${state.score} — NYAN collected: ${state.nyan}`, 'Run It Back');
+                const finalTimeMs = state.elapsedTime;
+                recordHighScore(finalTimeMs, state.score);
+                updateHighScorePanel();
+                updateTimerDisplay();
+                const formattedTime = formatTime(finalTimeMs);
+                showOverlay(`${message}\nFlight Time: ${formattedTime}\nFinal Score: ${state.score} — NYAN collected: ${state.nyan}`, 'Run It Back');
             }
 
             function updateCombo(delta) {
@@ -1865,6 +2092,7 @@
                 drawPlayer();
 
                 updateHUD();
+                updateTimerDisplay();
             }
 
             runCyborgLoadingSequence();


### PR DESCRIPTION
## Summary
- add a top-center survival timer with formatting helpers so pilots can see how long they’ve lasted
- persist each player’s top three survival times with accompanying scores using localStorage
- surface the personal leaderboard in the overlay and record results on game over, with an option to update the pilot callsign

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68cae2e3c29883249e2ebf601e3af864