### PR TITLE
Add rarity tiers for collectibles

### DIFF
--- a/index.html
+++ b/index.html
@@ -754,8 +754,38 @@
             const playerImage = new Image();
             playerImage.src = 'assets/player.png';
 
-            const collectibleImage = new Image();
-            collectibleImage.src = 'assets/point.png';
+            const collectibleTypes = [
+                {
+                    key: 'point1',
+                    imageSrc: 'assets/point.png',
+                    value: 1,
+                    weight: 0.68,
+                    color: { r: 255, g: 215, b: 0 }
+                },
+                {
+                    key: 'point2',
+                    imageSrc: 'assets/point2.png',
+                    value: 2,
+                    weight: 0.24,
+                    color: { r: 129, g: 212, b: 250 }
+                },
+                {
+                    key: 'point3',
+                    imageSrc: 'assets/point3.png',
+                    value: 3,
+                    weight: 0.08,
+                    color: { r: 255, g: 138, b: 101 }
+                }
+            ];
+
+            const collectibleImages = {};
+            for (const collectibleType of collectibleTypes) {
+                const image = new Image();
+                image.src = collectibleType.imageSrc;
+                collectibleImages[collectibleType.key] = image;
+            }
+
+            const collectibleWeightTotal = collectibleTypes.reduce((sum, type) => sum + type.weight, 0);
 
             const powerUpImageSources = {
                 powerBomb: 'assets/powerbomb.png',
@@ -1588,18 +1618,35 @@
                 }
             }
 
+            function getRandomCollectibleType() {
+                let roll = Math.random() * collectibleWeightTotal;
+                for (const type of collectibleTypes) {
+                    roll -= type.weight;
+                    if (roll <= 0) {
+                        return type;
+                    }
+                }
+                return collectibleTypes[collectibleTypes.length - 1];
+            }
+
             function spawnCollectible() {
                 const size = config.collectible.size ?? 32;
                 const verticalPadding = config.collectible.verticalPadding ?? 48;
                 const spawnRange = Math.max(canvas.height - size - verticalPadding * 2, 0);
                 const spawnY = verticalPadding + Math.random() * spawnRange;
+                const collectibleType = getRandomCollectibleType();
+                const baseColor = collectibleType.color ?? { r: 255, g: 215, b: 0 };
                 collectibles.push({
                     x: canvas.width + size,
                     y: spawnY,
                     width: size,
                     height: size,
                     speed: state.gameSpeed + (Math.random() * (config.collectible.maxSpeed - config.collectible.minSpeed) + config.collectible.minSpeed),
-                    wobbleTime: Math.random() * Math.PI * 2
+                    wobbleTime: Math.random() * Math.PI * 2,
+                    type: collectibleType.key,
+                    value: collectibleType.value,
+                    image: collectibleImages[collectibleType.key],
+                    color: { r: baseColor.r, g: baseColor.g, b: baseColor.b }
                 });
             }
 
@@ -1708,11 +1755,16 @@
 
                     if (rectOverlap(player, collectible)) {
                         collectibles.splice(i, 1);
-                        awardCollect();
+                        awardCollect(collectible);
+                        const particleColor = collectible.color ?? { r: 255, g: 215, b: 0 };
                         createParticles({
                             x: collectible.x + collectible.width * 0.5,
                             y: collectible.y + collectible.height * 0.5,
-                            color: { r: 255, g: 215, b: 0 }
+                            color: particleColor,
+                            count: 16 + (collectible.value ?? 1) * 4,
+                            speedRange: [120, 360 + (collectible.value ?? 1) * 30],
+                            sizeRange: [1.2, 3.8 + (collectible.value ?? 1) * 0.5],
+                            lifeRange: [420, 760]
                         });
                     }
                 }
@@ -2019,9 +2071,10 @@
                 });
             }
 
-            function awardCollect() {
-                state.nyan += 1;
-                awardScore(config.score.collect);
+            function awardCollect(collectible) {
+                const value = collectible?.value ?? 1;
+                state.nyan += value;
+                awardScore(config.score.collect * value);
             }
 
             function awardDestroy(obstacle) {
@@ -2201,34 +2254,50 @@
                     ctx.translate(collectible.x + collectible.width / 2, collectible.y + collectible.height / 2);
                     ctx.rotate(Math.sin(time * 0.004 + collectible.wobbleTime) * 0.2);
                     const pulse = Math.sin(time * 0.004 + collectible.wobbleTime);
-                    const spriteReady = collectibleImage.complete && collectibleImage.naturalWidth > 0;
+                    const sprite = collectible.image;
+                    const spriteReady = sprite?.complete && sprite?.naturalWidth > 0;
+                    const glowColor = collectible.color ?? { r: 255, g: 215, b: 0 };
+                    const glowString = (alpha) => `rgba(${glowColor.r}, ${glowColor.g}, ${glowColor.b}, ${alpha})`;
 
                     if (spriteReady) {
                         const glowRadius = collectible.width * (0.62 + 0.06 * pulse);
                         const gradient = ctx.createRadialGradient(0, 0, glowRadius * 0.35, 0, 0, glowRadius);
-                        gradient.addColorStop(0, 'rgba(255, 255, 255, 0.85)');
-                        gradient.addColorStop(1, 'rgba(255, 215, 0, 0.25)');
+                        gradient.addColorStop(0, glowString(0.85));
+                        gradient.addColorStop(1, glowString(0.18));
                         ctx.fillStyle = gradient;
                         ctx.beginPath();
                         ctx.arc(0, 0, glowRadius, 0, Math.PI * 2);
                         ctx.fill();
 
                         const drawSize = collectible.width * (0.94 + 0.08 * pulse);
-                        ctx.drawImage(collectibleImage, -drawSize / 2, -drawSize / 2, drawSize, drawSize);
+                        ctx.drawImage(sprite, -drawSize / 2, -drawSize / 2, drawSize, drawSize);
                     } else {
                         const gradient = ctx.createRadialGradient(0, 0, 4, 0, 0, collectible.width * 0.6);
-                        gradient.addColorStop(0, 'rgba(255, 255, 255, 0.9)');
-                        gradient.addColorStop(0.4, '#fff59d');
-                        gradient.addColorStop(1, 'rgba(255, 215, 0, 0.75)');
+                        gradient.addColorStop(0, glowString(0.9));
+                        gradient.addColorStop(0.4, glowString(0.55));
+                        gradient.addColorStop(1, glowString(0.35));
                         ctx.fillStyle = gradient;
                         ctx.beginPath();
                         ctx.arc(0, 0, collectible.width / 2, 0, Math.PI * 2);
                         ctx.fill();
-                        ctx.fillStyle = '#1a237e';
+                        ctx.fillStyle = '#0f172a';
                         ctx.font = `700 12px ${primaryFontStack}`;
                         ctx.textAlign = 'center';
                         ctx.textBaseline = 'middle';
-                        ctx.fillText('NYAN', 0, 0);
+                        ctx.fillText(`+${collectible.value ?? 1}`, 0, 0);
+                    }
+
+                    const labelValue = collectible.value ?? 1;
+                    if (labelValue > 1) {
+                        const labelSize = Math.max(12, collectible.width * 0.28);
+                        ctx.font = `700 ${labelSize}px ${primaryFontStack}`;
+                        ctx.textAlign = 'center';
+                        ctx.textBaseline = 'middle';
+                        ctx.lineWidth = Math.max(2, labelSize * 0.12);
+                        ctx.strokeStyle = glowString(0.5);
+                        ctx.strokeText(`+${labelValue}`, 0, collectible.width * 0.52);
+                        ctx.fillStyle = 'rgba(255, 255, 255, 0.95)';
+                        ctx.fillText(`+${labelValue}`, 0, collectible.width * 0.52);
                     }
                     ctx.restore();
                 }


### PR DESCRIPTION
## Summary
- load separate sprites for each collectible tier and pick them with weighted rarity
- track collectible value and color so NYAN, score, and particle effects respond to the tier grabbed
- adjust collectible rendering to show tier-specific glow, sprite, and labels for rarer rewards

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68cb05b17bd88324a9c3c8367368a1ce