### PR TITLE
Fix score panel sizing

### DIFF
--- a/index.html
+++ b/index.html
@@ -153,10 +153,20 @@
                 inset 0 0 0 1px rgba(94, 234, 212, 0.08);
             border: 1px solid rgba(148, 163, 184, 0.22);
             backdrop-filter: blur(12px);
-            min-width: clamp(220px, 22vw, 280px);
+            width: clamp(220px, 22vw, 280px);
+            flex: 0 0 clamp(220px, 22vw, 280px);
             display: flex;
             flex-direction: column;
             gap: 14px;
+        }
+
+        #stats .stat-row {
+            width: 100%;
+        }
+
+        #stats .value {
+            font-variant-numeric: tabular-nums;
+            font-feature-settings: 'tnum' 1;
         }
 
         #stats .stat-list {


### PR DESCRIPTION
## Summary
- lock the flight telemetry score panel to a fixed clamp width to stop it from resizing over the playfield
- use tabular number glyphs for score values so the digits no longer shift the container

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68cb10b0925883249028e86449f61a87