### PR TITLE
Relocate telemetry panel to sidebar

### DIFF
--- a/index.html
+++ b/index.html
@@ -128,22 +128,11 @@
             box-shadow: 0 20px 45px rgba(0, 0, 0, 0.55);
         }
 
-        #hudPanel {
-            position: absolute;
-            top: 12px;
-            right: 16px;
-            display: flex;
-            flex-direction: column;
-            align-items: flex-end;
-            gap: 12px;
-            z-index: 2;
-        }
-
         #stats {
             position: relative;
             font-size: 15px;
             line-height: 1.4;
-            text-align: right;
+            text-align: left;
             text-shadow: 0 0 6px rgba(0, 0, 0, 0.35);
             padding: 18px 20px 16px;
             border-radius: 18px;
@@ -153,8 +142,7 @@
                 inset 0 0 0 1px rgba(94, 234, 212, 0.08);
             border: 1px solid rgba(148, 163, 184, 0.22);
             backdrop-filter: blur(12px);
-            width: clamp(220px, 22vw, 280px);
-            flex: 0 0 clamp(220px, 22vw, 280px);
+            width: 100%;
             display: flex;
             flex-direction: column;
             gap: 14px;
@@ -642,8 +630,9 @@
     </div>
     <canvas id="gameCanvas" width="900" height="600" tabindex="0" aria-label="Nyan Escape flight deck"></canvas>
     <div id="survivalTimer">Flight Time: <span class="value" id="timerValue">00:00.0</span></div>
-    <div id="hudPanel" role="complementary" aria-label="Flight telemetry">
-        <section id="stats" aria-live="polite">
+    <aside id="instructions" aria-label="Flight telemetry, controls, and mission information">
+        <section id="stats" role="complementary" aria-live="polite">
+            <h2 class="card-title">Flight Telemetry</h2>
             <div class="stat-list" role="presentation">
                 <div class="stat-row">
                     <span class="stat-label">Score</span>
@@ -678,8 +667,6 @@
                 <div id="comboFill"></div>
             </div>
         </section>
-    </div>
-    <aside id="instructions" aria-label="Controls and mission information">
         <div class="hud-card collapsible open" id="controlsCard">
             <button class="card-toggle" type="button" id="controlsToggle" aria-expanded="true" aria-controls="controlsContent">
                 <span class="card-title">Flight Controls</span>


### PR DESCRIPTION
## Summary
- move the score and combo telemetry into the existing sidebar so it matches the control cards
- expand the stats card to use the sidebar width to avoid overlapping the playfield

## Testing
- not run (not provided)

------
https://chatgpt.com/codex/tasks/task_e_68cb143431e083248c0b927eaa573f9b