### PR TITLE
Add audio manager hooks for projectiles and explosions

### DIFF
--- a/index.html
+++ b/index.html
@@ -744,6 +744,114 @@
             const canvas = document.getElementById('gameCanvas');
             const ctx = canvas.getContext('2d');
 
+            const audioManager = (() => {
+                const isSupported = typeof window !== 'undefined' && typeof Audio === 'function';
+                const clamp01 = (value) => Math.max(0, Math.min(1, value));
+
+                const soundDefinitions = {
+                    projectile: {
+                        standard: { src: 'assets/audio/projectile-standard.mp3', voices: 6, volume: 0.55 },
+                        spread: { src: 'assets/audio/projectile-spread.mp3', voices: 6, volume: 0.52 },
+                        missile: { src: 'assets/audio/projectile-missile.mp3', voices: 4, volume: 0.6 }
+                    },
+                    explosion: {
+                        villain1: { src: 'assets/audio/explosion-villain1.mp3', voices: 3, volume: 0.7 },
+                        villain2: { src: 'assets/audio/explosion-villain2.mp3', voices: 3, volume: 0.7 },
+                        villain3: { src: 'assets/audio/explosion-villain3.mp3', voices: 3, volume: 0.75 },
+                        asteroid: { src: 'assets/audio/explosion-asteroid.mp3', voices: 3, volume: 0.68 },
+                        powerbomb: { src: 'assets/audio/explosion-powerbomb.mp3', voices: 2, volume: 0.76 },
+                        generic: { src: 'assets/audio/explosion-generic.mp3', voices: 3, volume: 0.66 }
+                    }
+                };
+
+                const pools = new Map();
+                const state = {
+                    masterVolume: 0.85,
+                    muted: false,
+                    unlocked: !isSupported
+                };
+
+                function createSoundPool(definition) {
+                    const { src, voices = 4 } = definition;
+                    const elements = [];
+                    let disabled = false;
+
+                    for (let i = 0; i < voices; i++) {
+                        const audio = new Audio(src);
+                        audio.preload = 'auto';
+                        audio.crossOrigin = 'anonymous';
+                        audio.volume = clamp01((definition.volume ?? 1) * state.masterVolume);
+                        audio.addEventListener('error', () => {
+                            disabled = true;
+                        });
+                        elements.push(audio);
+                    }
+
+                    let index = 0;
+
+                    return {
+                        play() {
+                            if (!isSupported || disabled || state.muted || !state.unlocked) {
+                                return;
+                            }
+
+                            const audio = elements[index];
+                            index = (index + 1) % elements.length;
+                            if (!audio) return;
+
+                            audio.volume = clamp01((definition.volume ?? 1) * state.masterVolume);
+                            if (!audio.paused) {
+                                audio.currentTime = 0;
+                            } else {
+                                audio.currentTime = 0;
+                            }
+
+                            const playPromise = audio.play();
+                            if (playPromise?.catch) {
+                                playPromise.catch(() => undefined);
+                            }
+                        }
+                    };
+                }
+
+                function getPool(category, key) {
+                    const definition = soundDefinitions[category]?.[key];
+                    if (!definition) {
+                        return null;
+                    }
+
+                    const mapKey = `${category}:${key}`;
+                    if (!pools.has(mapKey)) {
+                        pools.set(mapKey, createSoundPool(definition));
+                    }
+                    return pools.get(mapKey);
+                }
+
+                function play(category, key, fallbackKey) {
+                    if (!isSupported || state.muted) return;
+                    const pool = getPool(category, key) ?? (fallbackKey ? getPool(category, fallbackKey) : null);
+                    pool?.play();
+                }
+
+                function unlock() {
+                    if (state.unlocked) return;
+                    state.unlocked = true;
+                }
+
+                return {
+                    playProjectile(type) {
+                        play('projectile', type, 'standard');
+                    },
+                    playExplosion(type) {
+                        play('explosion', type, 'generic');
+                    },
+                    unlock
+                };
+            })();
+
+            window.addEventListener('pointerdown', audioManager.unlock, { once: true });
+            window.addEventListener('keydown', audioManager.unlock, { once: true });
+
             const backgroundImages = [
                 'assets/background1.png',
                 'assets/background2.png',
@@ -1829,6 +1937,7 @@
                 const asteroid = asteroids[index];
                 if (!asteroid) return;
                 createAsteroidDebris(asteroid);
+                audioManager.playExplosion('asteroid');
                 if (options.createSpark !== false) {
                     createHitSpark({ x: asteroid.x, y: asteroid.y, color: { r: 186, g: 198, b: 214 } });
                 }
@@ -2146,10 +2255,12 @@
             function spawnProjectiles() {
                 const originX = player.x + player.width - 12;
                 const originY = player.y + player.height * 0.5 - 6;
+                const firedTypes = new Set();
                 const createProjectile = (angle, type = 'standard') => {
                     const speed = config.projectileSpeed * (type === 'missile' ? 0.85 : 1);
                     const vx = Math.cos(angle) * speed;
                     const vy = Math.sin(angle) * speed;
+                    firedTypes.add(type);
                     projectiles.push({
                         x: originX,
                         y: originY,
@@ -2172,6 +2283,10 @@
                     createProjectile(spread, 'spread');
                 } else {
                     createProjectile(0, 'standard');
+                }
+
+                for (const type of firedTypes) {
+                    audioManager.playProjectile(type);
                 }
             }
 
@@ -2558,6 +2673,7 @@
                     hitSet: new WeakSet()
                 };
                 areaBursts.push(burst);
+                audioManager.playExplosion('powerbomb');
                 createParticles({
                     x: centerX,
                     y: centerY,
@@ -3052,6 +3168,7 @@
                 }
 
                 villainExplosions.push(explosion);
+                audioManager.playExplosion(villainKey ?? 'generic');
 
                 switch (explosion.type) {
                     case 'ionBurst': {


### PR DESCRIPTION
## Summary
- add a pooled audio manager that maps projectile and explosion events to dedicated sound assets and unlocks playback on first interaction
- trigger projectile-specific fire sounds and villain, asteroid, and powerbomb explosions through the new audio manager

## Testing
- not run (project has no automated tests)


------
https://chatgpt.com/codex/tasks/task_e_68cb1c56bf1c8324a1b57457ebadf42f