### PR TITLE
Fix double-tap dash detection

### DIFF
--- a/index.html
+++ b/index.html
@@ -2466,9 +2466,6 @@
 
             window.addEventListener('keyup', (event) => {
                 keys.delete(event.code);
-                if (dashDirections[event.code]) {
-                    dashTapTracker.delete(event.code);
-                }
             });
 
             window.addEventListener('blur', () => {


### PR DESCRIPTION
## Summary
- preserve dash tap timestamps through keyup events so a second tap can be detected
- ensure double-tapping directional keys now triggers the dash boost

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cb4b7200d083248ec7dd87e1ae0b39