### PR TITLE
Ensure point tiers and asteroids use provided art assets

### DIFF
--- a/index.html
+++ b/index.html
@@ -1771,7 +1771,7 @@
             const asteroidImageSources =
                 Array.isArray(assetOverrides.asteroids) && assetOverrides.asteroids.length
                     ? assetOverrides.asteroids
-                    : Array.from({ length: 3 }, () => null);
+                    : ['assets/asteroid1.png', 'assets/asteroid2.png', 'assets/asteroid3.png'];
             const asteroidImages = asteroidImageSources.map((entry, index) =>
                 loadImageWithFallback(resolveAssetConfig(entry, null), () => createAsteroidFallbackDataUrl(index))
             );
@@ -1935,7 +1935,7 @@
                 {
                     key: 'point2',
                     label: 'POINT+',
-                    src: null,
+                    src: 'assets/point2.png',
                     points: Math.round(baseCollectScore * 1.75),
                     weight: 0.26,
                     sizeMultiplier: 1.08,
@@ -1948,7 +1948,7 @@
                 {
                     key: 'point3',
                     label: 'POINT++',
-                    src: null,
+                    src: 'assets/point3.png',
                     points: Math.round(baseCollectScore * 2.5),
                     weight: 0.12,
                     sizeMultiplier: 1.16,


### PR DESCRIPTION
## Summary
- default the higher-tier point collectibles to load `assets/point2.png` and `assets/point3.png`
- default asteroids to load `assets/asteroid1.png`, `assets/asteroid2.png`, and `assets/asteroid3.png` so user artwork displays automatically

## Testing
- no tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68cb61f5cf488324b5d01868ac96c240