### PR TITLE
Center loading layout and reposition HUD timer

### DIFF
--- a/index.html
+++ b/index.html
@@ -47,17 +47,20 @@
         #playfield {
             position: relative;
             display: flex;
+            flex-direction: column;
+            align-items: center;
             justify-content: center;
+            gap: clamp(12px, 2vw, 20px);
         }
 
         #loadingScreen {
             position: fixed;
             inset: 0;
-            display: grid;
-            grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
-            gap: clamp(24px, 4vw, 48px);
+            display: flex;
+            flex-direction: column;
             justify-content: center;
             align-items: center;
+            gap: clamp(24px, 4vw, 48px);
             padding: clamp(28px, 6vw, 80px);
             background:
                 linear-gradient(rgba(15, 23, 42, 0.88), rgba(15, 23, 42, 0.9)),
@@ -78,7 +81,7 @@
         }
 
         #loadingStatus {
-            text-align: left;
+            text-align: center;
             font-family: "Consolas", "Lucida Console", "Courier New", monospace;
             letter-spacing: 0.2em;
             color: #0f172a;
@@ -198,10 +201,8 @@
         }
 
         #survivalTimer {
-            position: absolute;
-            top: 12px;
-            left: 50%;
-            transform: translateX(-50%);
+            position: static;
+            transform: none;
             font-size: 16px;
             font-weight: 600;
             letter-spacing: 0.04em;
@@ -211,6 +212,7 @@
             box-shadow: 0 6px 18px rgba(0, 0, 0, 0.35);
             text-shadow: 0 0 6px rgba(0, 0, 0, 0.35);
             z-index: 2;
+            margin-top: clamp(8px, 1.5vw, 16px);
         }
 
         #survivalTimer .value {
@@ -861,14 +863,8 @@
                 gap: clamp(16px, 5vw, 24px);
             }
 
-            #loadingScreen {
-                grid-template-columns: 1fr;
-                justify-items: center;
-            }
-
             #loadingStatus {
                 width: min(480px, 100%);
-                text-align: left;
             }
 
         }


### PR DESCRIPTION
## Summary
- stack the loading overlay contents vertically so the logo and boot text stay centered
- adjust the playfield layout so the survival timer sits below the canvas instead of overlapping it

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68cdecb1d3b4832486b0d39e9b30957e