### PR TITLE
Reduce preflight overlay footprint

### DIFF
--- a/index.html
+++ b/index.html
@@ -626,14 +626,15 @@
             inset: 0;
             display: flex;
             flex-direction: column;
-            justify-content: center;
+            justify-content: flex-start;
             align-items: center;
             background: linear-gradient(rgba(5, 8, 25, 0.92), rgba(1, 3, 12, 0.94));
             text-align: center;
             padding: clamp(32px, 6vw, 64px);
-            gap: clamp(18px, 4vw, 32px);
+            gap: clamp(14px, 3vw, 24px);
             transition: opacity 200ms ease;
             z-index: 4;
+            overflow-y: auto;
         }
 
         #overlay.hidden {
@@ -642,9 +643,9 @@
         }
 
         #overlay h1 {
-            font-size: clamp(2.6rem, 7vw, 4.6rem);
+            font-size: clamp(1.95rem, 5.25vw, 3.45rem);
             margin: 0;
-            letter-spacing: clamp(0.35rem, 1.4vw, 0.85rem);
+            letter-spacing: clamp(0.26rem, 1.05vw, 0.64rem);
             color: #f9a8d4;
             text-shadow: 0 0 18px rgba(249, 168, 212, 0.55);
         }
@@ -657,8 +658,8 @@
             display: flex;
             flex-wrap: wrap;
             justify-content: center;
-            gap: clamp(16px, 3vw, 28px);
-            width: min(880px, 100%);
+            gap: clamp(12px, 2vw, 21px);
+            width: min(660px, 100%);
             margin: 0;
         }
 
@@ -667,14 +668,14 @@
         }
 
         .comic-panel {
-            flex: 1 1 clamp(220px, 28%, 280px);
-            min-height: 180px;
+            flex: 1 1 clamp(165px, 21%, 210px);
+            min-height: 140px;
             border-radius: 18px;
-            padding: clamp(16px, 2vw, 22px);
+            padding: clamp(12px, 1.5vw, 17px);
             position: relative;
             overflow: hidden;
             box-shadow:
-                0 18px 36px rgba(5, 8, 25, 0.6),
+                0 14px 28px rgba(5, 8, 25, 0.6),
                 inset 0 0 0 1px rgba(148, 210, 255, 0.22);
             background:
                 linear-gradient(135deg, rgba(56, 189, 248, 0.85), rgba(99, 102, 241, 0.72));
@@ -694,29 +695,29 @@
         }
 
         .comic-panel h3 {
-            font-size: 0.95rem;
-            letter-spacing: 0.18em;
+            font-size: 0.72rem;
+            letter-spacing: 0.12em;
             text-transform: uppercase;
             margin: 0 0 12px;
         }
 
         .comic-panel p {
             margin: 0;
-            font-size: 0.92rem;
-            line-height: 1.5;
+            font-size: 0.69rem;
+            line-height: 1.45;
         }
 
         #callsignForm {
             display: flex;
             flex-direction: column;
-            gap: 10px;
+            gap: 8px;
             align-items: center;
-            width: min(420px, 100%);
+            width: min(315px, 100%);
         }
 
         #callsignForm label {
-            font-size: 0.82rem;
-            letter-spacing: 0.18em;
+            font-size: 0.62rem;
+            letter-spacing: 0.14em;
             text-transform: uppercase;
             color: rgba(148, 210, 255, 0.82);
         }
@@ -735,7 +736,7 @@
             border: 1px solid rgba(148, 210, 255, 0.35);
             background: rgba(8, 16, 32, 0.86);
             color: rgba(226, 232, 240, 0.95);
-            padding: 12px 16px;
+            padding: 9px 12px;
             font: inherit;
             letter-spacing: 0.04em;
             box-shadow: inset 0 0 0 1px rgba(14, 165, 233, 0.15);
@@ -747,16 +748,16 @@
         }
 
         #callsignHint {
-            font-size: 0.75rem;
-            letter-spacing: 0.12em;
+            font-size: 0.56rem;
+            letter-spacing: 0.1em;
             text-transform: uppercase;
             color: rgba(148, 210, 255, 0.6);
         }
 
         #overlay p {
             margin: 0;
-            font-size: 1.02rem;
-            max-width: min(560px, 90vw);
+            font-size: 0.78rem;
+            max-width: min(420px, 90vw);
             color: rgba(224, 231, 255, 0.88);
             white-space: pre-line;
         }
@@ -765,11 +766,11 @@
             background: linear-gradient(135deg, rgba(56, 189, 248, 0.92), rgba(99, 102, 241, 0.92));
             border: none;
             border-radius: 999px;
-            padding: 14px 32px;
+            padding: 11px 24px;
             color: #fff;
-            font-size: 0.95rem;
+            font-size: 0.72rem;
             font-weight: 700;
-            letter-spacing: 0.18em;
+            letter-spacing: 0.14em;
             text-transform: uppercase;
             cursor: pointer;
             box-shadow: 0 18px 36px rgba(37, 99, 235, 0.45);
@@ -824,37 +825,37 @@
         #overlayPanels {
             display: flex;
             flex-wrap: wrap;
-            gap: 18px;
             justify-content: center;
             width: 100%;
-            max-width: 720px;
+            max-width: 540px;
+            gap: 14px;
         }
 
         #highScorePanel,
         #leaderboardPanel,
         #sharePanel {
             margin-top: 8px;
-            padding: 12px 18px;
+            padding: 9px 14px;
             border-radius: 12px;
             background: rgba(12, 15, 35, 0.6);
             box-shadow: inset 0 0 0 1px rgba(148, 163, 184, 0.18);
             text-align: left;
-            max-width: 320px;
+            max-width: 240px;
         }
 
         #highScoreTitle {
-            font-size: 0.85rem;
+            font-size: 0.64rem;
             text-transform: uppercase;
-            letter-spacing: 0.18em;
+            letter-spacing: 0.12em;
             margin-bottom: 8px;
             color: rgba(148, 163, 184, 0.95);
         }
 
         #leaderboardPanel .panel-title,
         #sharePanel .panel-title {
-            font-size: 0.85rem;
+            font-size: 0.64rem;
             text-transform: uppercase;
-            letter-spacing: 0.18em;
+            letter-spacing: 0.14em;
             margin-bottom: 8px;
             color: rgba(148, 163, 184, 0.95);
         }
@@ -866,7 +867,7 @@
             display: flex;
             flex-direction: column;
             gap: 6px;
-            font-size: 0.9rem;
+            font-size: 0.68rem;
         }
 
         #highScoreList li {
@@ -895,7 +896,7 @@
             display: flex;
             flex-direction: column;
             gap: 6px;
-            font-size: 0.9rem;
+            font-size: 0.68rem;
         }
 
         #leaderboardList li {
@@ -906,8 +907,8 @@
         }
 
         #leaderboardList li .meta {
-            font-size: 0.72rem;
-            letter-spacing: 0.08em;
+            font-size: 0.54rem;
+            letter-spacing: 0.06em;
             color: rgba(148, 163, 184, 0.78);
         }
 
@@ -918,22 +919,22 @@
         }
 
         #sharePanel {
-            max-width: 420px;
+            max-width: 315px;
             text-align: center;
         }
 
         #sharePanel .share-buttons {
             display: flex;
             flex-wrap: wrap;
-            gap: 10px;
-            margin-bottom: 10px;
+            gap: 8px;
+            margin-bottom: 8px;
             justify-content: center;
         }
 
         #sharePanel button.share-button {
             background: linear-gradient(135deg, #38bdf8, #6366f1);
-            padding: 10px 18px;
-            font-size: 0.9rem;
+            padding: 8px 14px;
+            font-size: 0.68rem;
             border-radius: 12px;
             border: none;
             color: #fff;
@@ -956,7 +957,7 @@
 
         #shareStatus {
             margin: 0;
-            font-size: 0.82rem;
+            font-size: 0.62rem;
             color: rgba(148, 210, 255, 0.85);
             min-height: 1.4em;
             text-align: center;


### PR DESCRIPTION
## Summary
- allow the preflight overlay to scroll instead of covering the entire viewport
- shrink overlay typography, panels, and form controls to roughly 75% of their previous size for a lighter presentation

## Testing
- no tests were run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ce1ee54f3c8324be1213fd636bae87