### PR TITLE
Prevent key handler from blocking overlay inputs

### DIFF
--- a/index.html
+++ b/index.html
@@ -3490,6 +3490,33 @@
 
             const keys = new Set();
             const dashTapTracker = new Map();
+            const formControlSelector = 'input, textarea, select, button, [role="button"], [contenteditable="true"]';
+            const textEntrySelector = [
+                'textarea',
+                '[contenteditable="true"]',
+                'input:not([type])',
+                'input[type="text"]',
+                'input[type="search"]',
+                'input[type="email"]',
+                'input[type="password"]',
+                'input[type="tel"]',
+                'input[type="url"]',
+                'input[type="number"]'
+            ].join(',');
+
+            function isFormControlTarget(target) {
+                if (!target || typeof target.closest !== 'function') {
+                    return false;
+                }
+                return Boolean(target.closest(formControlSelector));
+            }
+
+            function isTextEntryTarget(target) {
+                if (!target || typeof target.closest !== 'function') {
+                    return false;
+                }
+                return Boolean(target.closest(textEntrySelector));
+            }
             const keyAliasMap = {
                 ArrowUp: 'ArrowUp',
                 Up: 'ArrowUp',
@@ -4748,8 +4775,14 @@
                 if (!normalizedKey) {
                     return;
                 }
-                if (preventDefaultKeys.has(normalizedKey)) {
+                const target = event.target;
+                const isFormControl = isFormControlTarget(target);
+                const isTextEntry = isTextEntryTarget(target);
+                if (preventDefaultKeys.has(normalizedKey) && !isFormControl) {
                     event.preventDefault();
+                }
+                if (isTextEntry && normalizedKey !== 'Enter') {
+                    return;
                 }
                 keys.add(normalizedKey);
                 if (!event.repeat) {


### PR DESCRIPTION
## Summary
- ensure global keyboard handler skips form controls so overlay buttons respond to the space bar
- ignore navigation key handling when typing in the callsign field to keep text entry working

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ce25aaa6348324b377666a43f39ba1