### PR TITLE
Improve mobile layout and launch control placement

### DIFF
--- a/index.html
+++ b/index.html
@@ -30,14 +30,25 @@
             margin: 0;
             background: #000;
             display: flex;
-            justify-content: center;
-            align-items: flex-start;
+            flex-direction: column;
+            justify-content: flex-start;
+            align-items: center;
             min-height: 100vh;
             padding: clamp(24px, 5vw, 48px);
             font-family: var(--primary-font-stack);
             color: #fff;
             overflow: auto;
             position: relative;
+        }
+
+        #preflightBar {
+            width: min(1400px, 100%);
+            margin: 0 auto clamp(24px, 5vw, 36px);
+            padding-inline: clamp(24px, 5vw, 48px);
+            display: flex;
+            justify-content: center;
+            position: relative;
+            z-index: 2;
         }
 
         #gameShell {
@@ -50,6 +61,7 @@
             width: min(1400px, 100%);
             padding-inline: var(--layout-gap);
             z-index: 0;
+            margin-inline: auto;
         }
 
         #playfield {
@@ -59,6 +71,8 @@
             align-items: center;
             justify-content: center;
             gap: clamp(12px, 2vw, 20px);
+            width: min(900px, 100%);
+            margin-inline: auto;
         }
 
         #loadingScreen {
@@ -235,7 +249,8 @@
         }
 
         #preflightPrompt {
-            margin-top: clamp(18px, 4vw, 28px);
+            width: min(520px, 100%);
+            margin: 0;
             padding: clamp(10px, 2vw, 16px) clamp(24px, 6vw, 36px);
             border-radius: 999px;
             border: 1px solid rgba(94, 234, 212, 0.45);
@@ -247,7 +262,7 @@
             letter-spacing: 0.2em;
             text-transform: uppercase;
             text-align: center;
-            display: inline-flex;
+            display: flex;
             align-items: center;
             justify-content: center;
             gap: clamp(12px, 3vw, 20px);
@@ -1069,28 +1084,50 @@
             body {
                 padding: clamp(16px, 4vw, 28px);
                 padding-bottom: calc(var(--mobile-hud-collapsed-height) + clamp(18px, 4vw, 32px));
-                align-items: stretch;
+                align-items: center;
+            }
+
+            #preflightBar {
+                position: sticky;
+                top: clamp(12px, 4vw, 18px);
+                padding-inline: clamp(16px, 5vw, 24px);
+                margin-bottom: clamp(18px, 5vw, 28px);
+            }
+
+            #preflightPrompt {
+                width: 100%;
+                box-shadow: 0 12px 30px rgba(2, 6, 23, 0.45);
             }
 
             #gameShell {
                 gap: clamp(16px, 5vw, 24px);
                 grid-template-columns: 1fr;
                 width: 100%;
+                max-width: min(620px, 100%);
                 padding-inline: 0;
+                margin-inline: auto;
             }
 
             #playfield {
                 width: 100%;
+                max-width: min(540px, 100%);
             }
 
             canvas {
                 width: 100%;
                 height: auto;
                 max-width: 100%;
+                box-shadow: 0 12px 28px rgba(0, 0, 0, 0.45);
             }
 
             #loadingStatus {
                 width: min(480px, 100%);
+            }
+
+            #instructions {
+                box-shadow: 0 -14px 32px rgba(2, 6, 23, 0.55);
+                backdrop-filter: none;
+                -webkit-backdrop-filter: none;
             }
 
             #instructions {
@@ -1214,14 +1251,16 @@
         <div class="backgroundLayer visible" id="backgroundLayerA"></div>
         <div class="backgroundLayer" id="backgroundLayerB"></div>
     </div>
+    <div id="preflightBar">
+        <div id="preflightPrompt" role="status" aria-live="polite" hidden>
+            <span class="desktop-only">Press Enter to launch the run</span>
+            <button id="mobilePreflightButton" type="button" hidden aria-hidden="true">Tap to Launch</button>
+        </div>
+    </div>
     <div id="gameShell">
         <div id="playfield">
             <canvas id="gameCanvas" width="900" height="600" tabindex="0" aria-label="Nyan Escape flight deck"></canvas>
             <div id="survivalTimer">Flight Time: <span class="value" id="timerValue">00:00.0</span></div>
-            <div id="preflightPrompt" role="status" aria-live="polite" hidden>
-                <span class="desktop-only">Press Enter to launch the run</span>
-                <button id="mobilePreflightButton" type="button" hidden aria-hidden="true">Tap to Launch</button>
-            </div>
         </div>
         <aside id="instructions" aria-label="Flight telemetry, controls, and mission information">
             <nav id="instructionNav" aria-label="Quick mission links">


### PR DESCRIPTION
## Summary
- move the launch preflight prompt into a dedicated top bar so the control sits above the playfield
- center the playfield on smaller viewports and constrain its width for easier mobile gameplay
- lighten mobile visual effects to reduce GPU load and prevent touch lag

## Testing
- no automated tests were run (html/css changes only)

------
https://chatgpt.com/codex/tasks/task_e_68ce6bc64e848324a7b1a8c4ed6cc223