### PR TITLE
Implement responsive canvas viewport and QA overlay

### DIFF
--- a/index.html
+++ b/index.html
@@ -174,6 +174,31 @@
             box-shadow: 0 20px 45px rgba(0, 0, 0, 0.55);
         }
 
+        #debugOverlay {
+            position: absolute;
+            top: 12px;
+            left: 12px;
+            display: flex;
+            flex-direction: column;
+            gap: 4px;
+            padding: 10px 14px;
+            border-radius: 12px;
+            background: rgba(15, 23, 42, 0.82);
+            box-shadow:
+                0 12px 28px rgba(2, 6, 23, 0.45),
+                inset 0 0 0 1px rgba(94, 234, 212, 0.12);
+            font-family: "Consolas", "Lucida Console", "Courier New", monospace;
+            font-size: 12px;
+            letter-spacing: 0.04em;
+            color: rgba(226, 232, 240, 0.92);
+            pointer-events: none;
+            z-index: 2;
+        }
+
+        #debugOverlay.hidden {
+            display: none;
+        }
+
         #stats {
             position: sticky;
             top: 0;
@@ -604,6 +629,10 @@
             display: none;
             pointer-events: none;
             z-index: 1;
+            --touch-bottom: clamp(16px, 8vh, 72px);
+            --joystick-left: max(16px, calc(50% - 450px - 108px));
+            --fire-left: auto;
+            --fire-right: max(16px, calc(50% - 450px - 96px));
         }
 
         @media (pointer: coarse) {
@@ -616,8 +645,8 @@
             position: absolute;
             width: clamp(132px, 26vw, 188px);
             height: clamp(132px, 26vw, 188px);
-            left: max(16px, calc(50% - 450px - 108px));
-            bottom: clamp(16px, 8vh, 72px);
+            left: var(--joystick-left);
+            bottom: var(--touch-bottom);
             border-radius: 50%;
             background: rgba(15, 23, 42, 0.58);
             border: 2px solid rgba(148, 163, 184, 0.32);
@@ -653,8 +682,9 @@
 
         #fireButton {
             position: absolute;
-            right: max(16px, calc(50% - 450px - 96px));
-            bottom: clamp(20px, 8vh, 84px);
+            left: var(--fire-left);
+            right: var(--fire-right);
+            bottom: var(--touch-bottom);
             width: clamp(108px, 24vw, 160px);
             height: clamp(108px, 24vw, 160px);
             border-radius: 40px;
@@ -1259,7 +1289,12 @@
     </div>
     <div id="gameShell">
         <div id="playfield">
-            <canvas id="gameCanvas" width="900" height="600" tabindex="0" aria-label="Nyan Escape flight deck"></canvas>
+            <canvas id="gameCanvas" tabindex="0" aria-label="Nyan Escape flight deck"></canvas>
+            <div id="debugOverlay" aria-hidden="true" hidden>
+                <div data-debug-line="logical"></div>
+                <div data-debug-line="physical"></div>
+                <div data-debug-line="ratio"></div>
+            </div>
             <div id="survivalTimer">Flight Time: <span class="value" id="timerValue">00:00.0</span></div>
         </div>
         <aside id="instructions" aria-label="Flight telemetry, controls, and mission information">
@@ -2147,6 +2182,15 @@
             const joystickZone = document.getElementById('joystickZone');
             const joystickThumb = joystickZone?.querySelector('.joystick-thumb') ?? null;
             const fireButton = document.getElementById('fireButton');
+            const touchControls = document.getElementById('touchControls');
+            const debugOverlayEl = document.getElementById('debugOverlay');
+            const debugOverlayLines = debugOverlayEl
+                ? {
+                    logical: debugOverlayEl.querySelector('[data-debug-line="logical"]'),
+                    physical: debugOverlayEl.querySelector('[data-debug-line="physical"]'),
+                    ratio: debugOverlayEl.querySelector('[data-debug-line="ratio"]')
+                }
+                : {};
 
             const overlay = document.getElementById('overlay');
             const overlayMessage = document.getElementById('overlayMessage');
@@ -2189,6 +2233,290 @@
                     : null;
             let isTouchInterface = coarsePointerQuery?.matches ?? ('ontouchstart' in window);
             const TOUCH_SMOOTHING_RATE = 26;
+            const DEBUG_OVERLAY_STORAGE_KEY = 'nyanEscape.debugOverlay';
+            const TARGET_ASPECT_RATIO = 3 / 2;
+            const viewport = {
+                width: 900,
+                height: 600,
+                cssWidth: 900,
+                cssHeight: 600,
+                physicalWidth: 900,
+                physicalHeight: 600,
+                dpr: window.devicePixelRatio || 1
+            };
+
+            let debugOverlayEnabled = false;
+            let player = null;
+            try {
+                debugOverlayEnabled = window.localStorage.getItem(DEBUG_OVERLAY_STORAGE_KEY) === '1';
+            } catch {
+                debugOverlayEnabled = false;
+            }
+
+            let pendingResizeFrame = null;
+            let devicePixelRatioQuery = null;
+
+            function measureElementSize(element) {
+                if (!element) {
+                    return { width: 0, height: 0 };
+                }
+                const rect = element.getBoundingClientRect();
+                if (rect.width > 0 && rect.height > 0) {
+                    return { width: rect.width, height: rect.height };
+                }
+                const computed = window.getComputedStyle(element);
+                const width = parseFloat(computed.width) || element.offsetWidth || 0;
+                const height = parseFloat(computed.height) || element.offsetHeight || 0;
+                return { width, height };
+            }
+
+            function updateTouchControlsLayout() {
+                if (!touchControls || !canvas) {
+                    return;
+                }
+
+                const viewportHeight = window.visualViewport?.height ?? window.innerHeight ?? 0;
+                const viewportOffsetTop = window.visualViewport?.offsetTop ?? 0;
+                const canvasRect = canvas.getBoundingClientRect();
+                const bottomInset = Math.max(16, viewportHeight + viewportOffsetTop - canvasRect.bottom + 16);
+                touchControls.style.setProperty('--touch-bottom', `${Math.round(bottomInset)}px`);
+
+                const spacing = Math.max(16, Math.min(canvasRect.width * 0.08, 48));
+
+                if (joystickZone) {
+                    const { width: joystickWidth } = measureElementSize(joystickZone);
+                    const availableLeft = canvasRect.left;
+                    let joystickLeft;
+                    if (availableLeft >= joystickWidth + spacing + 16) {
+                        joystickLeft = availableLeft - joystickWidth - spacing;
+                    } else {
+                        joystickLeft = canvasRect.left + spacing;
+                        if (joystickLeft + joystickWidth > window.innerWidth - 16) {
+                            joystickLeft = Math.max(16, window.innerWidth * 0.5 - joystickWidth * 0.5);
+                        }
+                    }
+                    touchControls.style.setProperty('--joystick-left', `${Math.round(joystickLeft)}px`);
+                }
+
+                if (fireButton) {
+                    const { width: fireWidth } = measureElementSize(fireButton);
+                    const availableRight = Math.max(0, window.innerWidth - canvasRect.right);
+                    if (availableRight >= fireWidth + spacing + 16) {
+                        const fireRight = Math.max(16, availableRight - spacing);
+                        touchControls.style.setProperty('--fire-right', `${Math.round(fireRight)}px`);
+                        touchControls.style.setProperty('--fire-left', 'auto');
+                    } else {
+                        let fireLeft = canvasRect.right - fireWidth - spacing;
+                        if (fireLeft < 16) {
+                            fireLeft = Math.max(16, canvasRect.left + canvasRect.width - fireWidth - spacing);
+                        }
+                        if (fireLeft + fireWidth > window.innerWidth - 16) {
+                            fireLeft = Math.max(16, window.innerWidth - fireWidth - 16);
+                        }
+                        touchControls.style.setProperty('--fire-left', `${Math.round(fireLeft)}px`);
+                        touchControls.style.setProperty('--fire-right', 'auto');
+                    }
+                }
+            }
+
+            function updateDebugOverlay() {
+                if (!debugOverlayEl) {
+                    return;
+                }
+
+                if (!debugOverlayEnabled) {
+                    debugOverlayEl.classList.add('hidden');
+                    debugOverlayEl.setAttribute('hidden', '');
+                    return;
+                }
+
+                debugOverlayEl.classList.remove('hidden');
+                debugOverlayEl.removeAttribute('hidden');
+
+                if (debugOverlayLines.logical) {
+                    debugOverlayLines.logical.textContent = `Logical: ${Math.round(viewport.width)} × ${Math.round(viewport.height)}`;
+                }
+                if (debugOverlayLines.physical) {
+                    debugOverlayLines.physical.textContent = `Physical: ${viewport.physicalWidth} × ${viewport.physicalHeight}`;
+                }
+                if (debugOverlayLines.ratio) {
+                    debugOverlayLines.ratio.textContent = `devicePixelRatio: ${viewport.dpr.toFixed(2)} (CSS: ${Math.round(viewport.cssWidth)} × ${Math.round(viewport.cssHeight)})`;
+                }
+            }
+
+            function setDebugOverlayEnabled(enabled) {
+                debugOverlayEnabled = Boolean(enabled);
+                try {
+                    if (debugOverlayEnabled) {
+                        window.localStorage.setItem(DEBUG_OVERLAY_STORAGE_KEY, '1');
+                    } else {
+                        window.localStorage.removeItem(DEBUG_OVERLAY_STORAGE_KEY);
+                    }
+                } catch {
+                    // Ignore storage errors
+                }
+                updateDebugOverlay();
+            }
+
+            function toggleDebugOverlay() {
+                setDebugOverlayEnabled(!debugOverlayEnabled);
+            }
+
+            function measureAvailableCanvasSize() {
+                const parent = canvas?.parentElement ?? null;
+                const parentRect = parent?.getBoundingClientRect();
+                const availableWidth = Math.max(240, Math.floor(parentRect?.width ?? window.innerWidth ?? viewport.width));
+                let availableHeight = Math.floor((window.innerHeight ?? viewport.height) - (parentRect?.top ?? 0) - 32);
+                if (!Number.isFinite(availableHeight) || availableHeight <= 0) {
+                    availableHeight = Math.max(240, Math.floor((window.innerHeight ?? viewport.height) * 0.8));
+                }
+                return { width: availableWidth, height: Math.max(240, availableHeight) };
+            }
+
+            function rescaleWorld(previousWidth, previousHeight, nextWidth, nextHeight) {
+                if (!previousWidth || !previousHeight || previousWidth === nextWidth || previousHeight === nextHeight) {
+                    return;
+                }
+                const scaleX = nextWidth / previousWidth;
+                const scaleY = nextHeight / previousHeight;
+
+                if (Number.isFinite(scaleX) && Number.isFinite(scaleY)) {
+                    if (player) {
+                        player.x *= scaleX;
+                        player.y *= scaleY;
+                        const verticalBleed = nextHeight * (config?.player?.verticalBleed ?? 0);
+                        player.x = clamp(player.x, 0, Math.max(0, nextWidth - player.width));
+                        player.y = clamp(
+                            player.y,
+                            -verticalBleed,
+                            Math.max(0, nextHeight - player.height + verticalBleed)
+                        );
+                    }
+
+                    for (const star of stars) {
+                        star.x *= scaleX;
+                        star.y *= scaleY;
+                        star.x = Math.max(-star.size, Math.min(nextWidth + star.size, star.x));
+                        star.y = Math.max(0, Math.min(nextHeight, star.y));
+                    }
+
+                    for (const asteroid of asteroids) {
+                        asteroid.x *= scaleX;
+                        asteroid.y = clamp(asteroid.y * scaleY, asteroid.radius, nextHeight - asteroid.radius);
+                        const maxX = nextWidth + (config?.asteroid?.clusterRadius ?? 160);
+                        asteroid.x = Math.min(asteroid.x, maxX);
+                    }
+                }
+            }
+
+            function updateViewportMetrics({ preserveEntities = true } = {}) {
+                if (!canvas || !ctx) {
+                    return;
+                }
+
+                const previousWidth = viewport.width;
+                const previousHeight = viewport.height;
+                const available = measureAvailableCanvasSize();
+
+                let cssWidth = Math.min(available.width, available.height * TARGET_ASPECT_RATIO);
+                if (!Number.isFinite(cssWidth) || cssWidth <= 0) {
+                    cssWidth = viewport.width;
+                }
+                if (cssWidth < 240) {
+                    cssWidth = Math.min(available.width, 240);
+                }
+                let cssHeight = cssWidth / TARGET_ASPECT_RATIO;
+                if (cssHeight > available.height) {
+                    cssHeight = available.height;
+                    cssWidth = cssHeight * TARGET_ASPECT_RATIO;
+                }
+
+                const dpr = Math.max(1, Math.min(4, window.devicePixelRatio || 1));
+                const physicalWidth = Math.max(1, Math.round(cssWidth * dpr));
+                const physicalHeight = Math.max(1, Math.round(cssHeight * dpr));
+
+                canvas.style.width = `${cssWidth}px`;
+                canvas.style.height = `${cssHeight}px`;
+
+                if (canvas.width !== physicalWidth) {
+                    canvas.width = physicalWidth;
+                }
+                if (canvas.height !== physicalHeight) {
+                    canvas.height = physicalHeight;
+                }
+
+                viewport.width = cssWidth;
+                viewport.height = cssHeight;
+                viewport.cssWidth = cssWidth;
+                viewport.cssHeight = cssHeight;
+                viewport.physicalWidth = physicalWidth;
+                viewport.physicalHeight = physicalHeight;
+                viewport.dpr = dpr;
+
+                ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+                enableHighQualitySmoothing(ctx);
+
+                if (preserveEntities) {
+                    rescaleWorld(previousWidth, previousHeight, cssWidth, cssHeight);
+                }
+
+                updateTouchControlsLayout();
+                updateDebugOverlay();
+            }
+
+            function requestViewportUpdate() {
+                if (pendingResizeFrame !== null) {
+                    return;
+                }
+                pendingResizeFrame = window.requestAnimationFrame(() => {
+                    pendingResizeFrame = null;
+                    updateViewportMetrics();
+                });
+            }
+
+            function cleanupDevicePixelRatioWatcher() {
+                if (!devicePixelRatioQuery) {
+                    return;
+                }
+                if (typeof devicePixelRatioQuery.removeEventListener === 'function') {
+                    devicePixelRatioQuery.removeEventListener('change', handleDevicePixelRatioChange);
+                } else if (typeof devicePixelRatioQuery.removeListener === 'function') {
+                    devicePixelRatioQuery.removeListener(handleDevicePixelRatioChange);
+                }
+                devicePixelRatioQuery = null;
+            }
+
+            function handleDevicePixelRatioChange() {
+                cleanupDevicePixelRatioWatcher();
+                requestViewportUpdate();
+                watchDevicePixelRatio();
+            }
+
+            function watchDevicePixelRatio() {
+                if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') {
+                    return;
+                }
+                cleanupDevicePixelRatioWatcher();
+                const dpr = window.devicePixelRatio || 1;
+                const query = window.matchMedia(`(resolution: ${dpr}dppx)`);
+                if (typeof query.addEventListener === 'function') {
+                    query.addEventListener('change', handleDevicePixelRatioChange, { once: true });
+                } else if (typeof query.addListener === 'function') {
+                    query.addListener(handleDevicePixelRatioChange);
+                }
+                devicePixelRatioQuery = query;
+            }
+
+            updateViewportMetrics({ preserveEntities: false });
+            watchDevicePixelRatio();
+            updateDebugOverlay();
+
+            window.addEventListener('resize', requestViewportUpdate);
+            window.addEventListener('orientationchange', requestViewportUpdate);
+            if (window.visualViewport) {
+                window.visualViewport.addEventListener('resize', requestViewportUpdate);
+                window.visualViewport.addEventListener('scroll', requestViewportUpdate);
+            }
 
             const getLaunchControlText = () => (isTouchInterface ? 'Tap to Launch' : 'Press Enter to Launch');
             const getRetryControlText = () => (isTouchInterface ? 'Tap to Retry' : 'Press Enter to Retry');
@@ -2209,6 +2537,7 @@
                         ? 'Tap Launch to start a run.'
                         : 'Press Enter or click Launch to start a run.';
                 }
+                updateTouchControlsLayout();
             }
 
             refreshInteractionHints();
@@ -4142,9 +4471,9 @@
             );
             bossVillainType.image = bossImage;
 
-            const player = {
-                x: canvas.width * 0.18,
-                y: canvas.height * 0.5,
+            player = {
+                x: viewport.width * 0.18,
+                y: viewport.height * 0.5,
                 width: config.player.width,
                 height: config.player.height,
                 vx: 0,
@@ -4183,8 +4512,8 @@
                 hyperBeamState.wave = 0;
                 hyperBeamState.sparkTimer = 0;
                 hyperBeamState.bounds = null;
-                player.x = canvas.width * 0.18;
-                player.y = canvas.height * 0.5;
+                player.x = viewport.width * 0.18;
+                player.y = viewport.height * 0.5;
                 player.vx = 0;
                 player.vy = 0;
                 projectiles.length = 0;
@@ -4224,8 +4553,8 @@
                 stars.length = 0;
                 for (let i = 0; i < config.star.count; i++) {
                     stars.push({
-                        x: Math.random() * canvas.width,
-                        y: Math.random() * canvas.height,
+                        x: Math.random() * viewport.width,
+                        y: Math.random() * viewport.height,
                         speed: (Math.random() * 0.8 + 0.4) * config.star.baseSpeed,
                         size: Math.random() * 2.5 + 0.6,
                         twinkleOffset: Math.random() * Math.PI * 2
@@ -4288,22 +4617,22 @@
                     if (anchor) {
                         candidateX = anchor.x + randomBetween(-clusterRadius, clusterRadius);
                         if (!initial) {
-                            candidateX = Math.max(candidateX, canvas.width - clusterRadius * 0.8);
+                            candidateX = Math.max(candidateX, viewport.width - clusterRadius * 0.8);
                         }
                         candidateY = anchor.y + randomBetween(-clusterRadius * 0.6, clusterRadius * 0.6);
                     } else if (initial) {
-                        candidateX = Math.random() * canvas.width;
-                        candidateY = Math.random() * canvas.height;
+                        candidateX = Math.random() * viewport.width;
+                        candidateY = Math.random() * viewport.height;
                     } else {
-                        candidateX = canvas.width + spawnOffset + Math.random() * clusterRadius;
-                        candidateY = Math.random() * canvas.height;
+                        candidateX = viewport.width + spawnOffset + Math.random() * clusterRadius;
+                        candidateY = Math.random() * viewport.height;
                     }
 
-                    candidateX = clamp(candidateX, asteroid.radius + minSpacing, canvas.width + clusterRadius);
+                    candidateX = clamp(candidateX, asteroid.radius + minSpacing, viewport.width + clusterRadius);
                     candidateY = clamp(
                         candidateY,
                         asteroid.radius + minSpacing,
-                        canvas.height - asteroid.radius - minSpacing
+                        viewport.height - asteroid.radius - minSpacing
                     );
 
                     let overlaps = false;
@@ -4324,8 +4653,8 @@
                     }
                 }
 
-                asteroid.x = initial ? Math.random() * canvas.width : canvas.width + asteroid.size;
-                asteroid.y = clamp(Math.random() * canvas.height, asteroid.radius, canvas.height - asteroid.radius);
+                asteroid.x = initial ? Math.random() * viewport.width : viewport.width + asteroid.size;
+                asteroid.y = clamp(Math.random() * viewport.height, asteroid.radius, viewport.height - asteroid.radius);
             }
 
             function resolveAsteroidCollisions() {
@@ -4447,13 +4776,13 @@
                 }
 
                 const spawnOffset = settings.spawnOffset ?? 140;
-                const spawnX = canvas.width + spawnOffset;
+                const spawnX = viewport.width + spawnOffset;
                 const scale = settings.scale ?? 1;
                 const minSize = Array.isArray(settings.sizeRange) ? settings.sizeRange[0] ?? 40 : 40;
                 const actualSize = minSize * scale;
                 const minSpacing = settings.minSpacing ?? 12;
                 const minY = actualSize * 0.5 + minSpacing;
-                const maxY = canvas.height - actualSize * 0.5 - minSpacing;
+                const maxY = viewport.height - actualSize * 0.5 - minSpacing;
                 const centerY = clamp(Math.random() * (maxY - minY) + minY, minY, maxY);
                 const speedMultiplier = settings.meteorShowerSpeedMultiplier ?? 1;
 
@@ -4562,8 +4891,8 @@
                     if (asteroid.y < asteroid.radius) {
                         asteroid.y = asteroid.radius;
                         asteroid.vy = Math.abs(asteroid.vy || targetVy);
-                    } else if (asteroid.y > canvas.height - asteroid.radius) {
-                        asteroid.y = canvas.height - asteroid.radius;
+                    } else if (asteroid.y > viewport.height - asteroid.radius) {
+                        asteroid.y = viewport.height - asteroid.radius;
                         asteroid.vy = -Math.abs(asteroid.vy || targetVy);
                     }
 
@@ -4609,9 +4938,9 @@
 
                 resolveAsteroidCollisions();
 
-                const maxX = canvas.width + (settings.clusterRadius ?? 160);
+                const maxX = viewport.width + (settings.clusterRadius ?? 160);
                 for (const asteroid of asteroids) {
-                    asteroid.y = clamp(asteroid.y, asteroid.radius, canvas.height - asteroid.radius);
+                    asteroid.y = clamp(asteroid.y, asteroid.radius, viewport.height - asteroid.radius);
                     asteroid.x = Math.min(asteroid.x, maxX);
                 }
             }
@@ -5252,6 +5581,11 @@
                 if (!normalizedKey) {
                     return;
                 }
+                if (event.ctrlKey && event.shiftKey && normalizedKey === 'KeyD') {
+                    event.preventDefault();
+                    toggleDebugOverlay();
+                    return;
+                }
                 const target = event.target;
                 const isFormControl = isFormControlTarget(target);
                 const isTextEntry = isTextEntryTarget(target);
@@ -5362,7 +5696,7 @@
                 const targetCenterY = playerCenterY + normalY * (playerHalfHeight + obstacleHalfHeight + clearance);
 
                 obstacle.x = targetCenterX - obstacleHalfWidth;
-                obstacle.y = clamp(targetCenterY - obstacleHalfHeight, 16, canvas.height - obstacle.height - 16);
+                obstacle.y = clamp(targetCenterY - obstacleHalfHeight, 16, viewport.height - obstacle.height - 16);
 
                 const knockback = shieldConfig.obstacleKnockback ?? 520;
                 obstacle.vx = normalX * knockback;
@@ -5388,7 +5722,7 @@
                 const playerRadius = Math.max(player.width, player.height) * 0.5;
                 const targetDistance = playerRadius + asteroid.radius + clearance;
                 asteroid.x = playerCenterX + normalX * targetDistance;
-                asteroid.y = clamp(playerCenterY + normalY * targetDistance, asteroid.radius, canvas.height - asteroid.radius);
+                asteroid.y = clamp(playerCenterY + normalY * targetDistance, asteroid.radius, viewport.height - asteroid.radius);
 
                 const knockback = shieldConfig.asteroidKnockback ?? 420;
                 asteroid.vx = normalX * knockback;
@@ -5501,9 +5835,9 @@
                     state.dashTimer = Math.max(0, state.dashTimer - delta);
                 }
 
-                player.x = clamp(player.x, 0, canvas.width - player.width);
-                const verticalBleed = canvas.height * config.player.verticalBleed;
-                player.y = clamp(player.y, -verticalBleed, canvas.height - player.height + verticalBleed);
+                player.x = clamp(player.x, 0, viewport.width - player.width);
+                const verticalBleed = viewport.height * config.player.verticalBleed;
+                player.y = clamp(player.y, -verticalBleed, viewport.height - player.height + verticalBleed);
 
                 attemptShoot(delta);
 
@@ -5542,11 +5876,11 @@
                 pumpTailState.waveTime = 0;
                 pumpTailState.fade = 0;
                 pumpTailState.centerX = player.x + player.width * 0.3;
-                pumpTailState.spread = Math.min(canvas.width * 0.85, Math.max(180, barCount * 26));
+                pumpTailState.spread = Math.min(viewport.width * 0.85, Math.max(180, barCount * 26));
                 const lengthFactor = state.tailLength / Math.max(1, config.baseTrailLength);
                 pumpTailState.baseHeight = Math.min(
-                    canvas.height * 0.52,
-                    canvas.height * (0.16 + Math.min(0.32, lengthFactor * 0.26))
+                    viewport.height * 0.52,
+                    viewport.height * (0.16 + Math.min(0.32, lengthFactor * 0.26))
                 );
                 pumpTailState.amplitude = 0.38 + Math.min(1.1, lengthFactor * 0.5);
                 pumpTailState.frequency = 1.6 + Math.min(1.6, lengthFactor * 0.35);
@@ -5573,7 +5907,7 @@
                     return;
                 }
 
-                const baseY = canvas.height - 28;
+                const baseY = viewport.height - 28;
                 const barCount = pumpTailState.bars.length;
                 const spacing = barCount > 1 ? pumpTailState.spread / (barCount - 1) : 0;
                 const startX = pumpTailState.centerX - (barCount > 1 ? pumpTailState.spread / 2 : 0);
@@ -5585,7 +5919,7 @@
                     const x = clamp(
                         startX + i * spacing,
                         baseWidth * 0.5,
-                        canvas.width - baseWidth * 0.5
+                        viewport.width - baseWidth * 0.5
                     );
                     const wave = Math.sin(pumpTailState.waveTime + normalizedIndex * 1.6 + bar.phase);
                     const normalizedWave = wave * 0.5 + 0.5;
@@ -5654,16 +5988,16 @@
                         deltaSeconds * 2.4
                     );
                     const targetBaseHeight = Math.min(
-                        canvas.height * 0.52,
-                        canvas.height * (0.16 + Math.min(0.32, lengthFactor * 0.26))
+                        viewport.height * 0.52,
+                        viewport.height * (0.16 + Math.min(0.32, lengthFactor * 0.26))
                     );
                     pumpTailState.baseHeight = moveTowards(
                         pumpTailState.baseHeight,
                         targetBaseHeight,
-                        deltaSeconds * canvas.height * 0.6
+                        deltaSeconds * viewport.height * 0.6
                     );
                     const targetSpread = Math.min(
-                        canvas.width * 0.85,
+                        viewport.width * 0.85,
                         Math.max(180, Math.round(state.tailLength) * 26)
                     );
                     pumpTailState.spread = moveTowards(
@@ -5779,10 +6113,10 @@
                     projectile.life -= delta;
 
                     if (
-                        projectile.x > canvas.width + 80 ||
+                        projectile.x > viewport.width + 80 ||
                         projectile.x + projectile.width < -80 ||
                         projectile.y < -120 ||
-                        projectile.y > canvas.height + 120 ||
+                        projectile.y > viewport.height + 120 ||
                         projectile.life <= 0
                     ) {
                         projectiles.splice(i, 1);
@@ -5805,10 +6139,10 @@
                 switch (behavior.type) {
                     case 'sine': {
                         const amplitude = behavior.amplitude ?? 40;
-                        const available = Math.max(0, canvas.height - size - amplitude * 2);
-                        const baseY = available > 0 ? Math.random() * available + amplitude : Math.random() * (canvas.height - size);
+                        const available = Math.max(0, viewport.height - size - amplitude * 2);
+                        const baseY = available > 0 ? Math.random() * available + amplitude : Math.random() * (viewport.height - size);
                         const phase = Math.random() * Math.PI * 2;
-                        const initialY = clamp(baseY + Math.sin(phase) * amplitude, 0, canvas.height - size);
+                        const initialY = clamp(baseY + Math.sin(phase) * amplitude, 0, viewport.height - size);
                         Object.assign(state, {
                             amplitude,
                             speed: behavior.speed ?? 3,
@@ -5820,9 +6154,9 @@
                     }
                     case 'hover': {
                         const amplitude = behavior.amplitude ?? 40;
-                        const center = Math.random() * (canvas.height - size);
+                        const center = Math.random() * (viewport.height - size);
                         const lowerBound = 16;
-                        const upperBound = Math.max(lowerBound, canvas.height - size - lowerBound);
+                        const upperBound = Math.max(lowerBound, viewport.height - size - lowerBound);
                         let minY = clamp(center - amplitude, lowerBound, upperBound);
                         let maxY = clamp(center + amplitude, lowerBound, upperBound);
                         if (minY > maxY) {
@@ -5840,7 +6174,7 @@
                         break;
                     }
                     case 'drift': {
-                        const initialY = Math.random() * (canvas.height - size);
+                        const initialY = Math.random() * (viewport.height - size);
                         const maxVertical = behavior.verticalSpeed ?? 120;
                         Object.assign(state, {
                             vy: randomBetween(-maxVertical, maxVertical),
@@ -5850,7 +6184,7 @@
                         break;
                     }
                     case 'tracker': {
-                        const initialY = Math.random() * (canvas.height - size);
+                        const initialY = Math.random() * (viewport.height - size);
                         Object.assign(state, {
                             vy: 0,
                             acceleration: behavior.acceleration ?? 120,
@@ -5860,7 +6194,7 @@
                         break;
                     }
                     default: {
-                        state.initialY = Math.random() * (canvas.height - size);
+                        state.initialY = Math.random() * (viewport.height - size);
                         break;
                     }
                 }
@@ -5887,14 +6221,14 @@
                 const width = bossVillainType.width;
                 const height = bossVillainType.height ?? width;
                 const spawnY = clamp(
-                    canvas.height * 0.5 - height * 0.5,
+                    viewport.height * 0.5 - height * 0.5,
                     32,
-                    canvas.height - height - 32
+                    viewport.height - height - 32
                 );
                 const hoverAmplitude = bossVillainType.behavior?.amplitude ?? 0;
                 const hoverSpeed = bossVillainType.behavior?.verticalSpeed ?? 60;
                 const lowerBound = 16;
-                const upperBound = Math.max(lowerBound, canvas.height - height - lowerBound);
+                const upperBound = Math.max(lowerBound, viewport.height - height - lowerBound);
                 let minY = clamp(spawnY - hoverAmplitude, lowerBound, upperBound);
                 let maxY = clamp(spawnY + hoverAmplitude, lowerBound, upperBound);
                 if (minY > maxY) {
@@ -5911,7 +6245,7 @@
                 };
 
                 obstacles.push({
-                    x: canvas.width + width,
+                    x: viewport.width + width,
                     y: clamp(spawnY, minY, maxY),
                     width,
                     height,
@@ -5963,11 +6297,11 @@
                 const size = randomBetween(villainType.size.min, villainType.size.max);
                 const health = getVillainHealth(size, villainType);
                 const behaviorState = createVillainBehaviorState(villainType, size);
-                const spawnY = behaviorState.initialY ?? Math.random() * (canvas.height - size);
+                const spawnY = behaviorState.initialY ?? Math.random() * (viewport.height - size);
                 delete behaviorState.initialY;
                 const rotationSpeed = randomBetween(villainType.rotation.min, villainType.rotation.max);
                 obstacles.push({
-                    x: canvas.width + size,
+                    x: viewport.width + size,
                     y: spawnY,
                     width: size,
                     height: size,
@@ -6000,10 +6334,10 @@
                 const baseSize = config.collectible.size ?? 32;
                 const size = baseSize * (tier.sizeMultiplier ?? 1);
                 const verticalPadding = config.collectible.verticalPadding ?? 48;
-                const spawnRange = Math.max(canvas.height - size - verticalPadding * 2, 0);
+                const spawnRange = Math.max(viewport.height - size - verticalPadding * 2, 0);
                 const spawnY = verticalPadding + Math.random() * spawnRange;
                 collectibles.push({
-                    x: canvas.width + size,
+                    x: viewport.width + size,
                     y: spawnY,
                     width: size,
                     height: size,
@@ -6047,8 +6381,8 @@
                 const type = powerUpTypes[Math.floor(Math.random() * powerUpTypes.length)];
                 const size = config.powerUp.size;
                 powerUps.push({
-                    x: canvas.width + size,
-                    y: Math.random() * (canvas.height - size * 2) + size,
+                    x: viewport.width + size,
+                    y: Math.random() * (viewport.height - size * 2) + size,
                     width: size,
                     height: size,
                     speed: state.gameSpeed + (Math.random() * (config.powerUp.maxSpeed - config.powerUp.minSpeed) + config.powerUp.minSpeed),
@@ -6064,7 +6398,7 @@
                 }
                 const powerUp = spawnPowerUp();
                 if (powerUp) {
-                    powerUp.x = canvas.width - powerUp.width * 0.5;
+                    powerUp.x = viewport.width - powerUp.width * 0.5;
                 }
                 state.bossBattle.powerUpSpawned = true;
             }
@@ -6081,15 +6415,15 @@
                         behaviorState.phase += deltaSeconds * (behaviorState.speed ?? villainBehavior.speed ?? 3);
                         const amplitude = behaviorState.amplitude ?? villainBehavior.amplitude ?? 40;
                         const targetY = behaviorState.baseY + Math.sin(behaviorState.phase) * amplitude;
-                        obstacle.y = clamp(targetY, 0, canvas.height - obstacle.height);
+                        obstacle.y = clamp(targetY, 0, viewport.height - obstacle.height);
                         break;
                     }
                     case 'hover': {
                         const speed = behaviorState.speed ?? villainBehavior.verticalSpeed ?? 60;
                         const minY =
-                            behaviorState.minY ?? clamp(obstacle.y - (villainBehavior.amplitude ?? 0), 16, canvas.height - obstacle.height - 16);
+                            behaviorState.minY ?? clamp(obstacle.y - (villainBehavior.amplitude ?? 0), 16, viewport.height - obstacle.height - 16);
                         const maxY =
-                            behaviorState.maxY ?? clamp(obstacle.y + (villainBehavior.amplitude ?? 0), 16, canvas.height - obstacle.height - 16);
+                            behaviorState.maxY ?? clamp(obstacle.y + (villainBehavior.amplitude ?? 0), 16, viewport.height - obstacle.height - 16);
                         if (behaviorState.minY === undefined) {
                             behaviorState.minY = minY;
                         }
@@ -6114,8 +6448,8 @@
                         if (obstacle.y < 24) {
                             obstacle.y = 24;
                             behaviorState.vy = Math.abs(behaviorState.vy);
-                        } else if (obstacle.y + obstacle.height > canvas.height - 24) {
-                            obstacle.y = canvas.height - 24 - obstacle.height;
+                        } else if (obstacle.y + obstacle.height > viewport.height - 24) {
+                            obstacle.y = viewport.height - 24 - obstacle.height;
                             behaviorState.vy = -Math.abs(behaviorState.vy);
                         }
                         break;
@@ -6128,7 +6462,7 @@
                         const maxSpeed = behaviorState.maxSpeed ?? villainBehavior.maxSpeed ?? 180;
                         behaviorState.vy = clamp(behaviorState.vy, -maxSpeed, maxSpeed);
                         obstacle.y += behaviorState.vy * deltaSeconds;
-                        obstacle.y = clamp(obstacle.y, 16, canvas.height - obstacle.height - 16);
+                        obstacle.y = clamp(obstacle.y, 16, viewport.height - obstacle.height - 16);
                         break;
                     }
                     default:
@@ -6176,7 +6510,7 @@
                         continue;
                     }
 
-                    obstacle.y = clamp(obstacle.y, 16, canvas.height - obstacle.height - 16);
+                    obstacle.y = clamp(obstacle.y, 16, viewport.height - obstacle.height - 16);
 
                     if (isPumpTailDamaging() && pumpTailIntersectsRect(obstacle)) {
                         obstacles.splice(i, 1);
@@ -6225,7 +6559,7 @@
                     collectible.wobbleTime += deltaSeconds * 4;
                     collectible.y += Math.sin(collectible.wobbleTime) * 18 * deltaSeconds;
                     const verticalPadding = config.collectible.verticalPadding ?? 48;
-                    collectible.y = clamp(collectible.y, verticalPadding, canvas.height - collectible.height - verticalPadding);
+                    collectible.y = clamp(collectible.y, verticalPadding, viewport.height - collectible.height - verticalPadding);
 
                     if (collectible.x + collectible.width < 0) {
                         collectibles.splice(i, 1);
@@ -6294,7 +6628,7 @@
                     powerUp.x -= powerUp.speed * deltaSeconds;
                     powerUp.wobbleTime += deltaSeconds * config.powerUp.wobbleSpeed;
                     powerUp.y += Math.sin(powerUp.wobbleTime) * config.powerUp.wobbleAmplitude * deltaSeconds;
-                    powerUp.y = clamp(powerUp.y, 32, canvas.height - 32 - powerUp.height);
+                    powerUp.y = clamp(powerUp.y, 32, viewport.height - 32 - powerUp.height);
 
                     if (powerUp.x + powerUp.width < 0) {
                         powerUps.splice(i, 1);
@@ -6346,17 +6680,17 @@
 
             function computeHyperBeamBounds(hyperConfig) {
                 const startX = player.x + player.width * 0.55;
-                const width = Math.max(0, canvas.width - startX + (hyperConfig.extraLength ?? 40));
+                const width = Math.max(0, viewport.width - startX + (hyperConfig.extraLength ?? 40));
                 if (width <= 0) {
                     return null;
                 }
                 const { y: centerY } = getPlayerCenter();
-                const height = Math.min(hyperConfig.beamHeight ?? 180, canvas.height);
+                const height = Math.min(hyperConfig.beamHeight ?? 180, viewport.height);
                 let top = centerY - height / 2;
                 if (top < 0) {
                     top = 0;
-                } else if (top + height > canvas.height) {
-                    top = Math.max(0, canvas.height - height);
+                } else if (top + height > viewport.height) {
+                    top = Math.max(0, viewport.height - height);
                 }
                 return { x: startX, y: top, width, height };
             }
@@ -6617,8 +6951,8 @@
                     const star = stars[i];
                     star.x -= star.speed * deltaSeconds * (0.4 + state.gameSpeed / 600);
                     if (star.x < -star.size) {
-                        star.x = canvas.width + star.size;
-                        star.y = Math.random() * canvas.height;
+                        star.x = viewport.width + star.size;
+                        star.y = Math.random() * viewport.height;
                         star.speed = (Math.random() * 0.8 + 0.4) * config.star.baseSpeed;
                     }
                 }
@@ -6856,8 +7190,8 @@
                     return;
                 }
                 const alpha = clamp(remaining / BOSS_ALERT_DURATION, 0, 1);
-                const centerX = canvas.width / 2;
-                const centerY = canvas.height / 2;
+                const centerX = viewport.width / 2;
+                const centerY = viewport.height / 2;
                 const fontSize = 64 + Math.sin(time * 0.008) * 4;
                 ctx.save();
                 ctx.textAlign = 'center';
@@ -7487,13 +7821,13 @@
 
             function drawBackground() {
                 ctx.fillStyle = '#05091f';
-                ctx.fillRect(0, 0, canvas.width, canvas.height);
-                const gradient = ctx.createLinearGradient(0, 0, 0, canvas.height);
+                ctx.fillRect(0, 0, viewport.width, viewport.height);
+                const gradient = ctx.createLinearGradient(0, 0, 0, viewport.height);
                 gradient.addColorStop(0, 'rgba(26, 35, 126, 0.85)');
                 gradient.addColorStop(0.5, 'rgba(21, 11, 45, 0.85)');
                 gradient.addColorStop(1, 'rgba(0, 2, 12, 0.95)');
                 ctx.fillStyle = gradient;
-                ctx.fillRect(0, 0, canvas.width, canvas.height);
+                ctx.fillRect(0, 0, viewport.width, viewport.height);
             }
 
             function drawStars(time) {
@@ -7977,8 +8311,8 @@
                 const hyperConfig = config.hyperBeam ?? {};
                 const color = powerUpColors[HYPER_BEAM_POWER] ?? { r: 147, g: 197, b: 253 };
                 const verticalJitter = Math.sin(time * 0.008 + hyperBeamState.wave) * (hyperConfig.jitterAmplitude ?? 18) * intensity;
-                const top = clamp(bounds.y + verticalJitter * -0.5, 0, Math.max(0, canvas.height - bounds.height));
-                const height = Math.min(bounds.height, canvas.height - top);
+                const top = clamp(bounds.y + verticalJitter * -0.5, 0, Math.max(0, viewport.height - bounds.height));
+                const height = Math.min(bounds.height, viewport.height - top);
                 if (height <= 0) {
                     return;
                 }


### PR DESCRIPTION
## Summary
- add a viewport manager that sizes the canvas against the visual viewport and devicePixelRatio while exposing logical dimensions
- refactor gameplay positioning, spawning, and HUD drawing to consume the logical viewport instead of fixed canvas constants
- reflow touch controls and expose a debug overlay so QA can confirm logical vs physical resolution after resizes or orientation changes

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68ce78ecbe288324ac2164c4e9e1e690