### PR TITLE
Initialize reduced effects flag before use

### DIFF
--- a/index.html
+++ b/index.html
@@ -2884,6 +2884,7 @@
             const reducedEffectsToggle = document.getElementById('reducedEffectsToggle');
             const reducedEffectsStatus = document.getElementById('reducedEffectsStatus');
             const bodyElement = document.body;
+            let reducedEffectsMode = false;
             const instructionLinks = instructionNavEl
                 ? Array.from(instructionNavEl.querySelectorAll('a[data-panel-target]'))
                 : [];
@@ -4689,8 +4690,6 @@
                     getSnapshot: () => cachedSnapshot
                 };
             }
-
-            let reducedEffectsMode = false;
 
             function applyReducedEffectsFlag(enabled) {
                 reducedEffectsMode = Boolean(enabled);


### PR DESCRIPTION
## Summary
- initialize the reduced effects mode flag alongside other UI references to ensure it exists before settings are applied

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68ce880544508324ab2bcfbc9506fad3