### PR TITLE
Guard canvas detection when HTMLCanvasElement is unavailable

### DIFF
--- a/index.html
+++ b/index.html
@@ -3428,7 +3428,10 @@
             let lastComboPercent = -1;
             let lastFormattedTimer = '';
 
-            if (!(canvas instanceof HTMLCanvasElement) || !ctx) {
+            const isCanvasElement =
+                typeof HTMLCanvasElement !== 'undefined' && canvas instanceof HTMLCanvasElement;
+
+            if (!isCanvasElement || !ctx) {
                 console.error('Unable to initialize the Nyan Escape flight deck: canvas support is unavailable.');
 
                 loadingScreen?.classList.add('hidden');


### PR DESCRIPTION
## Summary
- avoid referencing `HTMLCanvasElement` when the browser does not support canvas elements
- fall back to the existing unsupported message so the boot sequence completes instead of crashing

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68ce89201a108324a7c95b34f5276ff2