### PR TITLE
Restyle HUD overlays with retro console frame

### DIFF
--- a/index.html
+++ b/index.html
@@ -437,33 +437,44 @@
             font-size: 15px;
             line-height: 1.4;
             text-align: left;
-            text-shadow: 0 0 6px rgba(0, 0, 0, 0.35);
-            padding: 18px 20px 16px;
-            border-radius: 18px;
-            background: linear-gradient(165deg, rgba(15, 23, 42, 0.88), rgba(8, 16, 32, 0.82));
+            font-family: "Flight Time", "Press Start 2P", "Consolas", monospace;
+            padding: clamp(18px, 4vw, 24px);
+            border-radius: 14px;
+            border: 4px solid #f4f4f4;
+            background: linear-gradient(180deg, #161616 0%, #0f0f0f 100%);
             box-shadow:
-                0 18px 38px rgba(2, 6, 23, 0.45),
-                inset 0 0 0 1px rgba(94, 234, 212, 0.08);
-            border: 1px solid rgba(148, 163, 184, 0.22);
-            backdrop-filter: blur(12px);
+                0 0 0 8px #202020,
+                0 20px 0 rgba(0, 0, 0, 0.4);
+            color: #f5f5f5;
             width: 100%;
             display: flex;
             flex-direction: column;
-            gap: 14px;
+            gap: clamp(14px, 3vw, 18px);
+            letter-spacing: 0.06em;
         }
 
-        #stats .stat-row {
-            width: 100%;
+        #stats::after {
+            content: "";
+            position: absolute;
+            inset: clamp(6px, 1.8vw, 8px);
+            border: 2px solid rgba(255, 255, 255, 0.14);
+            pointer-events: none;
+        }
+
+        #stats > * {
+            position: relative;
+            z-index: 1;
         }
 
         #stats .value {
             font-variant-numeric: tabular-nums;
             font-feature-settings: 'tnum' 1;
+            color: #8be9fd;
         }
 
         #stats .stat-list {
             display: grid;
-            gap: 10px;
+            gap: 12px;
             margin: 0;
             padding: 0;
             list-style: none;
@@ -474,14 +485,16 @@
             align-items: baseline;
             justify-content: space-between;
             gap: 16px;
-            color: rgba(226, 232, 240, 0.9);
+            color: #fefefe;
+            text-shadow: 0 2px 0 rgba(0, 0, 0, 0.65);
         }
 
         #stats .stat-label {
-            font-size: 0.68rem;
+            font-size: 0.66rem;
             text-transform: uppercase;
-            letter-spacing: 0.16em;
-            color: rgba(148, 163, 184, 0.85);
+            letter-spacing: 0.18em;
+            color: #f9f871;
+            text-shadow: 0 2px 0 rgba(0, 0, 0, 0.6);
         }
 
         #survivalTimer {
@@ -489,20 +502,24 @@
             top: clamp(14px, 3vw, 28px);
             left: 50%;
             transform: translateX(-50%);
-            font-size: 16px;
-            font-weight: 600;
-            letter-spacing: 0.04em;
-            padding: 6px 18px;
-            border-radius: 999px;
-            background: rgba(15, 23, 42, 0.78);
-            box-shadow: 0 6px 18px rgba(0, 0, 0, 0.35);
-            text-shadow: 0 0 6px rgba(0, 0, 0, 0.35);
+            font-size: 0.88rem;
+            font-family: "Flight Time", "Press Start 2P", "Consolas", monospace;
+            letter-spacing: 0.18em;
+            padding: 10px 28px 8px;
+            border-radius: 12px;
+            border: 3px solid #f4f4f4;
+            background: linear-gradient(180deg, #1e1e1e 0%, #111 100%);
+            box-shadow:
+                0 0 0 6px #202020,
+                0 12px 0 rgba(0, 0, 0, 0.35);
+            text-shadow: 0 2px 0 rgba(0, 0, 0, 0.65);
+            color: #fefefe;
             z-index: 2;
             pointer-events: none;
         }
 
         #survivalTimer .value {
-            color: #7dd3fc;
+            color: #f9f871;
         }
 
         #preflightPrompt {
@@ -613,7 +630,8 @@
 
         #stats span.value {
             font-weight: 700;
-            color: #ffd54f;
+            color: #8be9fd;
+            text-shadow: 0 2px 0 rgba(0, 0, 0, 0.6);
         }
 
         #stats #comboMeter {
@@ -645,23 +663,59 @@
         }
 
         #instructions .hud-card {
-            background: linear-gradient(165deg, rgba(15, 23, 42, 0.85), rgba(8, 16, 32, 0.78));
-            border-radius: 16px;
-            padding: 18px 20px;
-            box-shadow: 0 18px 38px rgba(2, 6, 23, 0.45), inset 0 0 0 1px rgba(94, 234, 212, 0.08);
-            border: 1px solid rgba(148, 163, 184, 0.18);
-            backdrop-filter: blur(12px);
+            position: relative;
+            background: linear-gradient(180deg, #161616 0%, #0f0f0f 100%);
+            border-radius: 14px;
+            border: 4px solid #f4f4f4;
+            padding: clamp(18px, 3.6vw, 24px);
+            box-shadow:
+                0 0 0 8px #202020,
+                0 20px 0 rgba(0, 0, 0, 0.4);
             display: flex;
             flex-direction: column;
-            gap: 14px;
+            gap: 16px;
+            color: #f5f5f5;
+            font-family: "Flight Time", "Press Start 2P", "Consolas", monospace;
+            letter-spacing: 0.06em;
+        }
+
+        #instructions .hud-card::after {
+            content: "";
+            position: absolute;
+            inset: clamp(6px, 1.8vw, 8px);
+            border: 2px solid rgba(255, 255, 255, 0.14);
+            pointer-events: none;
+        }
+
+        #instructions .hud-card > * {
+            position: relative;
+            z-index: 1;
         }
 
         #instructions .card-title {
-            font-size: 0.78rem;
+            display: inline-flex;
+            align-items: center;
+            justify-content: center;
+            padding: 8px 18px;
+            border: 3px solid #ffffff;
+            background: linear-gradient(180deg, #e53e3e 0%, #b91c1c 100%);
+            color: #ffffff;
+            font-size: 0.76rem;
             text-transform: uppercase;
-            letter-spacing: 0.18em;
-            color: rgba(148, 210, 255, 0.9);
-            margin: 0 0 12px;
+            letter-spacing: 0.2em;
+            margin: 0 0 10px;
+            box-shadow: 0 4px 0 #420d0d;
+        }
+
+        #instructions .card-body,
+        #instructions .control-action,
+        #instructions .mission-list,
+        #instructions .intel-log,
+        #instructions .challenge-item,
+        #instructions .cosmetic-options,
+        #socialFeed li {
+            font-family: var(--primary-font-stack);
+            letter-spacing: 0.02em;
         }
 
         #instructionNav {
@@ -670,14 +724,28 @@
             z-index: 2;
             display: flex;
             flex-wrap: wrap;
-            gap: 10px;
-            padding: 12px 2px 4px;
-            margin: 0 0 12px;
-            background: linear-gradient(165deg, rgba(15, 23, 42, 0.78), rgba(8, 16, 32, 0.74));
+            gap: 12px;
+            padding: clamp(12px, 3vw, 16px);
+            margin: 0 0 16px;
+            background: linear-gradient(180deg, #161616 0%, #0f0f0f 100%);
             border-radius: 14px;
-            border: 1px solid rgba(148, 210, 255, 0.18);
-            box-shadow: inset 0 0 0 1px rgba(94, 234, 212, 0.05);
-            backdrop-filter: blur(12px);
+            border: 4px solid #f4f4f4;
+            box-shadow:
+                0 0 0 8px #202020,
+                0 18px 0 rgba(0, 0, 0, 0.35);
+        }
+
+        #instructionNav::after {
+            content: "";
+            position: absolute;
+            inset: clamp(6px, 1.8vw, 8px);
+            border: 2px solid rgba(255, 255, 255, 0.14);
+            pointer-events: none;
+        }
+
+        #instructionNav > * {
+            position: relative;
+            z-index: 1;
         }
 
         #instructions section {
@@ -688,24 +756,25 @@
             display: inline-flex;
             align-items: center;
             justify-content: center;
-            padding: 6px 14px;
-            border-radius: 999px;
-            font-size: 0.68rem;
-            letter-spacing: 0.16em;
+            padding: 8px 20px;
+            min-width: 120px;
+            border-radius: 10px;
+            font-size: 0.64rem;
+            letter-spacing: 0.2em;
             text-transform: uppercase;
-            color: rgba(191, 219, 254, 0.9);
+            color: #ffffff;
             text-decoration: none;
-            border: 1px solid rgba(148, 210, 255, 0.28);
-            box-shadow: 0 6px 14px rgba(2, 6, 23, 0.35);
-            transition: transform 140ms ease, box-shadow 140ms ease, background 140ms ease, color 140ms ease;
+            border: 3px solid #f4f4f4;
+            background: linear-gradient(180deg, #2563eb 0%, #1d4ed8 100%);
+            box-shadow: 0 6px 0 #0f172a;
+            transition: transform 140ms ease, box-shadow 140ms ease, filter 140ms ease;
         }
 
         #instructionNav a:hover,
         #instructionNav a:focus-visible {
-            background: rgba(56, 189, 248, 0.22);
-            color: rgba(224, 242, 254, 0.95);
-            box-shadow: 0 10px 22px rgba(14, 116, 144, 0.35);
-            transform: translateY(-1px);
+            transform: translateY(-2px);
+            box-shadow: 0 8px 0 #0b1120;
+            filter: brightness(1.1);
             outline: none;
         }
 
@@ -716,7 +785,12 @@
 
         #instructionNav a:active {
             transform: translateY(1px);
-            box-shadow: 0 6px 12px rgba(2, 6, 23, 0.5);
+            box-shadow: 0 3px 0 #0b1120;
+        }
+
+        #instructionNav a[aria-expanded='true'] {
+            filter: brightness(1.15);
+            box-shadow: 0 8px 0 #0b1120;
         }
 
         #instructions .control-list {
@@ -748,12 +822,13 @@
             height: 28px;
             padding: 0 8px;
             border-radius: 8px;
-            border: 1px solid rgba(148, 163, 184, 0.35);
-            background: linear-gradient(135deg, rgba(30, 41, 59, 0.95), rgba(15, 23, 42, 0.85));
-            color: rgba(226, 232, 240, 0.95);
-            font-size: 0.78rem;
-            letter-spacing: 0.04em;
-            box-shadow: inset 0 -2px 6px rgba(13, 148, 136, 0.25);
+            border: 3px solid #f4f4f4;
+            background: linear-gradient(180deg, #101010 0%, #060606 100%);
+            color: #fefefe;
+            font-size: 0.76rem;
+            letter-spacing: 0.14em;
+            text-transform: uppercase;
+            box-shadow: 0 4px 0 #202020;
         }
 
         #instructions .keycap.wide {
@@ -762,8 +837,9 @@
 
         #instructions .control-action {
             flex: 1;
-            color: rgba(226, 232, 240, 0.86);
+            color: #fefefe;
             font-size: 0.88rem;
+            text-shadow: 0 2px 0 rgba(0, 0, 0, 0.6);
         }
 
         #instructions .mission-list {
@@ -778,7 +854,8 @@
         #instructions .mission-list li {
             position: relative;
             padding-left: 18px;
-            color: rgba(226, 232, 240, 0.92);
+            color: #fefefe;
+            text-shadow: 0 2px 0 rgba(0, 0, 0, 0.6);
         }
 
         #instructions .mission-list li::before {
@@ -790,15 +867,16 @@
             width: 8px;
             height: 8px;
             border-radius: 50%;
-            background: linear-gradient(135deg, #38bdf8, #6366f1);
-            box-shadow: 0 0 10px rgba(99, 102, 241, 0.6);
+            background: linear-gradient(180deg, #facc15 0%, #f97316 100%);
+            box-shadow: 0 0 10px rgba(250, 204, 21, 0.65);
         }
 
         #instructions .card-body {
             margin: 0;
-            color: rgba(224, 231, 255, 0.9);
+            color: rgba(255, 255, 255, 0.88);
             font-size: 0.88rem;
             line-height: 1.65;
+            text-shadow: 0 2px 0 rgba(0, 0, 0, 0.55);
         }
 
         #socialFeed {
@@ -814,9 +892,10 @@
             display: flex;
             flex-direction: column;
             gap: 4px;
-            color: rgba(226, 232, 240, 0.92);
+            color: #fefefe;
             padding-left: 12px;
             border-left: 2px solid rgba(96, 165, 250, 0.35);
+            text-shadow: 0 2px 0 rgba(0, 0, 0, 0.6);
         }
 
         #socialFeed li.type-score {
@@ -843,14 +922,14 @@
             font-size: 0.7rem;
             letter-spacing: 0.12em;
             text-transform: uppercase;
-            color: rgba(148, 163, 184, 0.7);
+            color: rgba(255, 255, 255, 0.6);
         }
 
         #socialFeed li.empty {
             border: none;
             padding-left: 0;
             font-style: italic;
-            color: rgba(148, 163, 184, 0.8);
+            color: rgba(255, 255, 255, 0.55);
         }
 
         #intelCard .card-body {
@@ -1191,13 +1270,33 @@
             flex-direction: column;
             justify-content: flex-start;
             align-items: center;
-            background: linear-gradient(rgba(5, 8, 25, 0.92), rgba(1, 3, 12, 0.94));
+            background: linear-gradient(180deg, #161616 0%, #0f0f0f 100%);
             text-align: center;
-            padding: clamp(32px, 6vw, 64px);
-            gap: clamp(14px, 3vw, 24px);
+            padding: clamp(36px, 7vw, 72px);
+            gap: clamp(18px, 4vw, 26px);
             transition: opacity 200ms ease;
             z-index: 4;
             overflow-y: auto;
+            border: 6px solid #f4f4f4;
+            box-shadow:
+                0 0 0 14px #202020,
+                0 32px 0 rgba(0, 0, 0, 0.45);
+            font-family: "Flight Time", "Press Start 2P", "Consolas", monospace;
+            color: #fefefe;
+            letter-spacing: 0.08em;
+        }
+
+        #overlay::after {
+            content: "";
+            position: absolute;
+            inset: clamp(18px, 5vw, 28px);
+            border: 2px solid rgba(255, 255, 255, 0.14);
+            pointer-events: none;
+        }
+
+        #overlay > * {
+            position: relative;
+            z-index: 1;
         }
 
         #overlay.hidden {
@@ -1206,11 +1305,18 @@
         }
 
         #overlay h1 {
-            font-size: clamp(1.95rem, 5.25vw, 3.45rem);
+            display: inline-flex;
+            align-items: center;
+            justify-content: center;
+            font-size: clamp(1.8rem, 5vw, 3.2rem);
             margin: 0;
-            letter-spacing: clamp(0.26rem, 1.05vw, 0.64rem);
-            color: #f9a8d4;
-            text-shadow: 0 0 18px rgba(249, 168, 212, 0.55);
+            letter-spacing: clamp(0.24rem, 1vw, 0.6rem);
+            text-transform: uppercase;
+            color: #ffffff;
+            padding: clamp(10px, 2.6vw, 14px) clamp(20px, 5vw, 30px);
+            border: 3px solid #ffffff;
+            background: linear-gradient(180deg, #e53e3e 0%, #b91c1c 100%);
+            box-shadow: 0 6px 0 #430b0b;
         }
 
         #overlay h1:empty {
@@ -1273,16 +1379,17 @@
         #callsignForm {
             display: flex;
             flex-direction: column;
-            gap: 8px;
+            gap: 12px;
             align-items: center;
-            width: min(315px, 100%);
+            width: min(320px, 100%);
         }
 
         #callsignForm label {
-            font-size: 0.62rem;
-            letter-spacing: 0.14em;
+            font-size: 0.64rem;
+            letter-spacing: 0.2em;
             text-transform: uppercase;
-            color: rgba(148, 210, 255, 0.82);
+            color: #f9f871;
+            text-shadow: 0 2px 0 rgba(0, 0, 0, 0.6);
         }
 
         #callsignForm .input-row {
@@ -1290,39 +1397,45 @@
             width: 100%;
             display: flex;
             flex-direction: column;
-            gap: 6px;
+            gap: 8px;
         }
 
         #playerNameInput {
             width: 100%;
-            border-radius: 14px;
-            border: 1px solid rgba(148, 210, 255, 0.35);
-            background: rgba(8, 16, 32, 0.86);
-            color: rgba(226, 232, 240, 0.95);
-            padding: 9px 12px;
-            font: inherit;
-            letter-spacing: 0.04em;
-            box-shadow: inset 0 0 0 1px rgba(14, 165, 233, 0.15);
+            border-radius: 12px;
+            border: 3px solid #f4f4f4;
+            background: linear-gradient(180deg, #101010 0%, #050505 100%);
+            color: #8be9fd;
+            padding: 12px 14px 10px;
+            font-family: "Flight Time", "Press Start 2P", "Consolas", monospace;
+            font-size: 0.78rem;
+            letter-spacing: 0.16em;
+            text-transform: uppercase;
+            box-shadow:
+                inset 0 -3px 0 rgba(0, 0, 0, 0.6),
+                0 6px 0 #202020;
         }
 
         #playerNameInput:focus-visible {
-            outline: 2px solid rgba(148, 210, 255, 0.75);
-            outline-offset: 3px;
+            outline: 2px solid #f9f871;
+            outline-offset: 4px;
         }
 
         #callsignHint {
             font-size: 0.56rem;
-            letter-spacing: 0.1em;
+            letter-spacing: 0.16em;
             text-transform: uppercase;
-            color: rgba(148, 210, 255, 0.6);
+            color: rgba(255, 255, 255, 0.72);
+            text-shadow: 0 2px 0 rgba(0, 0, 0, 0.5);
         }
 
         #overlay p {
             margin: 0;
             font-size: 0.78rem;
             max-width: min(420px, 90vw);
-            color: rgba(224, 231, 255, 0.88);
+            color: rgba(255, 255, 255, 0.84);
             white-space: pre-line;
+            text-shadow: 0 2px 0 rgba(0, 0, 0, 0.6);
         }
 
         #overlayActions {
@@ -1338,51 +1451,49 @@
         }
 
         #overlay button {
-            background: linear-gradient(135deg, rgba(56, 189, 248, 0.92), rgba(99, 102, 241, 0.92));
-            border: none;
-            border-radius: 999px;
-            padding: 11px 24px;
-            color: #fff;
+            background: linear-gradient(180deg, #2563eb 0%, #1d4ed8 100%);
+            border: 3px solid #f4f4f4;
+            border-radius: 12px;
+            padding: 12px 26px 10px;
+            color: #ffffff;
             font-size: 0.72rem;
             font-weight: 700;
-            letter-spacing: 0.14em;
+            letter-spacing: 0.2em;
             text-transform: uppercase;
             cursor: pointer;
-            box-shadow: 0 18px 36px rgba(37, 99, 235, 0.45);
-            transition: transform 160ms ease, box-shadow 160ms ease;
+            box-shadow: 0 8px 0 #0f172a;
+            transition: transform 160ms ease, box-shadow 160ms ease, filter 160ms ease;
         }
 
         #overlay button:hover {
             transform: translateY(-2px);
-            box-shadow: 0 22px 46px rgba(37, 99, 235, 0.52);
+            box-shadow: 0 10px 0 #0b1120;
+            filter: brightness(1.08);
         }
 
         #overlay button:active {
             transform: translateY(1px);
-            box-shadow: 0 14px 28px rgba(37, 99, 235, 0.48);
+            box-shadow: 0 4px 0 #0b1120;
         }
 
         #overlay button[disabled] {
             cursor: default;
             opacity: 0.65;
-            box-shadow: none;
+            box-shadow: 0 6px 0 #131c33;
         }
 
         #overlaySecondaryButton {
-            background: transparent;
-            border: 1px solid rgba(148, 210, 255, 0.45);
-            color: rgba(224, 231, 255, 0.88);
-            box-shadow: none;
+            background: linear-gradient(180deg, #0b0b0b 0%, #050505 100%);
+            color: rgba(255, 255, 255, 0.82);
+            border-color: #f4f4f4;
         }
 
         #overlaySecondaryButton:hover {
-            transform: translateY(-1px);
-            box-shadow: 0 16px 32px rgba(37, 99, 235, 0.3);
+            filter: brightness(1.05);
         }
 
         #overlaySecondaryButton:active {
-            transform: translateY(1px);
-            box-shadow: 0 12px 24px rgba(37, 99, 235, 0.28);
+            box-shadow: 0 3px 0 #131313;
         }
 
         #overlay.unsupported #highScorePanel {
@@ -1390,28 +1501,30 @@
         }
 
         #comboMeter {
-            width: 160px;
-            height: 8px;
-            border-radius: 999px;
+            width: 180px;
+            height: 12px;
+            border-radius: 12px;
             overflow: hidden;
-            background: rgba(255, 255, 255, 0.12);
-            margin-top: 8px;
+            background: #040404;
+            margin-top: 10px;
+            border: 2px solid #f4f4f4;
+            box-shadow: inset 0 -2px 0 rgba(0, 0, 0, 0.6);
         }
 
         #comboFill {
             width: 0%;
             height: 100%;
-            background: linear-gradient(90deg, #6a5acd, #00e5ff);
+            background: linear-gradient(90deg, #f43f5e, #f97316, #facc15);
             transition: width 100ms ease-out;
         }
 
         #comboMeter.charged {
-            background: rgba(16, 185, 129, 0.32);
-            box-shadow: 0 0 14px rgba(16, 185, 129, 0.45);
+            background: #04160c;
+            box-shadow: 0 0 14px rgba(248, 250, 109, 0.45);
         }
 
         #comboMeter.charged #comboFill {
-            filter: drop-shadow(0 0 6px rgba(16, 185, 129, 0.75));
+            filter: drop-shadow(0 0 6px rgba(248, 250, 109, 0.85));
         }
 
         #overlayPanels {
@@ -1426,30 +1539,46 @@
         #highScorePanel,
         #leaderboardPanel,
         #sharePanel {
-            margin-top: 8px;
-            padding: 9px 14px;
-            border-radius: 12px;
-            background: rgba(12, 15, 35, 0.6);
-            box-shadow: inset 0 0 0 1px rgba(148, 163, 184, 0.18);
+            position: relative;
+            margin-top: 12px;
+            padding: clamp(14px, 3vw, 18px);
+            border-radius: 14px;
+            border: 4px solid #f4f4f4;
+            background: linear-gradient(180deg, #161616 0%, #0f0f0f 100%);
+            box-shadow:
+                0 0 0 8px #202020,
+                0 18px 0 rgba(0, 0, 0, 0.4);
             text-align: left;
-            max-width: 240px;
+            max-width: 260px;
+            font-family: "Flight Time", "Press Start 2P", "Consolas", monospace;
         }
 
-        #highScoreTitle {
-            font-size: 0.64rem;
-            text-transform: uppercase;
-            letter-spacing: 0.12em;
-            margin-bottom: 8px;
-            color: rgba(148, 163, 184, 0.95);
+        #highScorePanel::after,
+        #leaderboardPanel::after,
+        #sharePanel::after {
+            content: "";
+            position: absolute;
+            inset: 10px;
+            border: 2px solid rgba(255, 255, 255, 0.14);
+            pointer-events: none;
         }
 
+        #highScorePanel > *,
+        #leaderboardPanel > *,
+        #sharePanel > * {
+            position: relative;
+            z-index: 1;
+        }
+
+        #highScoreTitle,
         #leaderboardPanel .panel-title,
         #sharePanel .panel-title {
             font-size: 0.64rem;
             text-transform: uppercase;
-            letter-spacing: 0.14em;
-            margin-bottom: 8px;
-            color: rgba(148, 163, 184, 0.95);
+            letter-spacing: 0.18em;
+            margin-bottom: 10px;
+            color: #f9f871;
+            text-shadow: 0 2px 0 rgba(0, 0, 0, 0.65);
         }
 
         #highScoreList {
@@ -1463,12 +1592,13 @@
         }
 
         #highScoreList li {
-            color: rgba(226, 232, 240, 0.92);
+            color: #fefefe;
+            text-shadow: 0 2px 0 rgba(0, 0, 0, 0.6);
         }
 
         #highScoreList li.empty {
             list-style: none;
-            color: rgba(148, 163, 184, 0.85);
+            color: rgba(255, 255, 255, 0.55);
             font-style: italic;
         }
 
@@ -1492,21 +1622,22 @@
         }
 
         #leaderboardList li {
-            color: rgba(226, 232, 240, 0.92);
+            color: #fefefe;
             display: flex;
             flex-direction: column;
             gap: 2px;
+            text-shadow: 0 2px 0 rgba(0, 0, 0, 0.6);
         }
 
         #leaderboardList li .meta {
             font-size: 0.54rem;
             letter-spacing: 0.06em;
-            color: rgba(148, 163, 184, 0.78);
+            color: rgba(255, 255, 255, 0.7);
         }
 
         #leaderboardList li.empty {
             list-style: none;
-            color: rgba(148, 163, 184, 0.85);
+            color: rgba(255, 255, 255, 0.55);
             font-style: italic;
         }
 
@@ -1524,39 +1655,44 @@
         }
 
         #sharePanel button.share-button {
-            background: linear-gradient(135deg, #38bdf8, #6366f1);
-            padding: 8px 14px;
-            font-size: 0.68rem;
+            background: linear-gradient(180deg, #2563eb 0%, #1d4ed8 100%);
+            padding: 10px 18px 8px;
+            font-size: 0.64rem;
             border-radius: 12px;
-            border: none;
-            color: #fff;
-            font-weight: 600;
+            border: 3px solid #f4f4f4;
+            color: #ffffff;
+            font-weight: 700;
             cursor: pointer;
-            box-shadow: 0 10px 26px rgba(14, 165, 233, 0.35);
-            transition: transform 140ms ease, box-shadow 140ms ease;
+            box-shadow: 0 6px 0 #0f172a;
+            letter-spacing: 0.16em;
+            text-transform: uppercase;
+            transition: transform 140ms ease, box-shadow 140ms ease, filter 140ms ease;
         }
 
         #sharePanel button.share-button:hover {
-            transform: translateY(-1px);
-            box-shadow: 0 14px 32px rgba(14, 165, 233, 0.45);
+            transform: translateY(-2px);
+            box-shadow: 0 8px 0 #0b1120;
+            filter: brightness(1.08);
         }
 
         #sharePanel button.share-button:disabled {
             opacity: 0.6;
             cursor: not-allowed;
-            box-shadow: none;
+            box-shadow: 0 4px 0 #0f172a;
         }
 
         #shareStatus {
             margin: 0;
-            font-size: 0.62rem;
-            color: rgba(148, 210, 255, 0.85);
+            font-size: 0.6rem;
+            color: rgba(255, 255, 255, 0.8);
             min-height: 1.4em;
             text-align: center;
+            letter-spacing: 0.14em;
+            text-transform: uppercase;
         }
 
         #shareStatus.success {
-            color: rgba(129, 230, 217, 0.9);
+            color: #8be9fd;
         }
 
         #shareStatus.error {


### PR DESCRIPTION
## Summary
- restyle the flight telemetry panel, instructions, and survival timer with a Nintendo-inspired bezel and typography
- refresh the launch overlay, callsign form, and leaderboard/share panels to reuse the new retro console framing and buttons
- align control hints, social feed, and combo meter styling with the preflight overlay aesthetic for a consistent HUD

## Testing
- Not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68ced807227c8324bd43cb7fcd821ecf