### PR TITLE
Adjust preflight overlay sizing and placement

### DIFF
--- a/index.html
+++ b/index.html
@@ -271,16 +271,18 @@
         }
 
         #preflightBar {
-            width: min(520px, 100%);
-            padding: 0 clamp(16px, 4vw, 24px);
+            width: 100%;
+            max-width: clamp(260px, 28vw, 360px);
+            padding: 0;
             display: flex;
             flex-direction: column;
             justify-content: center;
-            align-items: stretch;
+            align-items: flex-start;
             gap: clamp(12px, 3vw, 16px);
             position: relative;
             z-index: 2;
-            margin: 0 auto;
+            margin: clamp(16px, 3vw, 24px) 0 0;
+            align-self: flex-start;
         }
 
         #gameShell {
@@ -509,23 +511,23 @@
             position: relative;
             width: 100%;
             margin: 0;
-            padding: clamp(16px, 4vw, 22px);
+            padding: clamp(12px, 3vw, 18px);
             border-radius: 12px;
-            border: 4px solid #f4f4f4;
+            border: 3px solid #f4f4f4;
             background: linear-gradient(180deg, #161616 0%, #111 100%);
             box-shadow:
-                0 0 0 8px #202020,
-                0 18px 0 rgba(0, 0, 0, 0.35);
+                0 0 0 6px #202020,
+                0 14px 0 rgba(0, 0, 0, 0.35);
             color: #fefefe;
             font-family: "Flight Time", "Press Start 2P", "Consolas", monospace;
-            font-size: clamp(13px, 2.4vw, 16px);
+            font-size: clamp(12px, 2.2vw, 15px);
             font-weight: 600;
-            letter-spacing: 0.14em;
+            letter-spacing: 0.12em;
             text-transform: uppercase;
-            text-align: center;
+            text-align: left;
             display: grid;
             gap: clamp(10px, 2vw, 16px);
-            justify-items: center;
+            justify-items: start;
             pointer-events: auto;
         }
 
@@ -551,7 +553,7 @@
             border: 3px solid #ffffff;
             background: linear-gradient(180deg, #e53e3e 0%, #b91c1c 100%);
             color: #ffffff;
-            font-size: clamp(12px, 2vw, 14px);
+            font-size: clamp(11px, 1.8vw, 13px);
             letter-spacing: 0.16em;
             box-shadow: 0 4px 0 #450a0a;
         }
@@ -598,8 +600,9 @@
 
         #settingsHint {
             display: flex;
-            justify-content: center;
+            justify-content: flex-start;
             align-items: center;
+            width: 100%;
             padding: 8px 12px;
             border-radius: 8px;
             border: 2px solid rgba(255, 255, 255, 0.18);
@@ -608,7 +611,7 @@
             letter-spacing: 0.16em;
             text-transform: uppercase;
             color: rgba(226, 232, 240, 0.92);
-            text-align: center;
+            text-align: left;
         }
 
         #stats span.value {
@@ -1677,13 +1680,12 @@
             }
 
             #preflightBar {
-                width: 100%;
-                padding: 0 clamp(12px, 6vw, 20px);
-                margin: 0 auto;
+                max-width: min(320px, 100%);
+                padding: 0;
+                margin: clamp(16px, 5vw, 24px) 0 0 clamp(12px, 6vw, 20px);
             }
 
             #preflightPrompt {
-                width: 100%;
                 border-width: 3px;
                 box-shadow:
                     0 0 0 6px #202020,


### PR DESCRIPTION
## Summary
- reduce the preflight prompt dimensions and align its contents so it no longer overflows the viewport
- anchor the preflight bar beneath the playfield toward the bottom-left and left-align the settings hint
- tune the mobile breakpoint styles to keep the preflight UI within safe margins on smaller screens

## Testing
- not run (static site change)


------
https://chatgpt.com/codex/tasks/task_e_68cee0bf74748324abb04549a8a23543