### PR TITLE
Fix config initialization order for character selection

### DIFF
--- a/index.html
+++ b/index.html
@@ -7403,11 +7403,6 @@
                     }
                 });
             }
-            const initialCharacterProfile = getCharacterProfile(activeCharacterId);
-            if (initialCharacterProfile) {
-                setActiveCharacter(initialCharacterProfile);
-                setPendingCharacter(initialCharacterProfile.id, { updateSummary: false });
-            }
             const challengeManager = createChallengeManager({
                 definitions: CHALLENGE_DEFINITIONS,
                 cosmeticsCatalog,
@@ -7590,6 +7585,11 @@
                 cooldown: config.projectileCooldown,
                 speed: config.projectileSpeed
             };
+            const initialCharacterProfile = getCharacterProfile(activeCharacterId);
+            if (initialCharacterProfile) {
+                setActiveCharacter(initialCharacterProfile);
+                setPendingCharacter(initialCharacterProfile.id, { updateSummary: false });
+            }
             const baseCollectScoreRaw = config?.score?.collect;
             const baseCollectScore = Number.isFinite(Number(baseCollectScoreRaw))
                 ? Math.max(1, Number(baseCollectScoreRaw))


### PR DESCRIPTION
## Summary
- move the initial character activation logic to run after the gameplay config is constructed
- ensure character overrides only run once base tuning data is available, preventing early access to `config`

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68cef0aef278832488fa628837c2fdde