### PR TITLE
Fix config initialization order to prevent runtime error

### DIFF
--- a/index.html
+++ b/index.html
@@ -7173,6 +7173,13 @@
                     ember: trailStyles.ember
                 }
             };
+            const config = applyOverrides(cloneConfig(defaultConfig), gameplayOverrides ?? {});
+            const basePlayerConfig = cloneConfig(config.player);
+            const baseDashConfig = cloneConfig(config.player.dash);
+            const baseProjectileSettings = {
+                cooldown: config.projectileCooldown,
+                speed: config.projectileSpeed
+            };
             function getCharacterProfile(id) {
                 return characterProfileMap.get(id ?? '') ?? null;
             }
@@ -7578,13 +7585,6 @@
                 }
             };
 
-            const config = applyOverrides(cloneConfig(defaultConfig), gameplayOverrides ?? {});
-            const basePlayerConfig = cloneConfig(config.player);
-            const baseDashConfig = cloneConfig(config.player.dash);
-            const baseProjectileSettings = {
-                cooldown: config.projectileCooldown,
-                speed: config.projectileSpeed
-            };
             const initialCharacterProfile = getCharacterProfile(activeCharacterId);
             if (initialCharacterProfile) {
                 setActiveCharacter(initialCharacterProfile);


### PR DESCRIPTION
## Summary
- initialize the gameplay configuration before character tuning helpers so they can safely reference it

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68cef4a9b7108324b16df9fd37a122f6