### PR TITLE
Refine overlays and stabilize container layouts

### DIFF
--- a/index.html
+++ b/index.html
@@ -132,6 +132,10 @@
             display: flex;
             flex-direction: column;
             gap: 18px;
+            max-height: min(90vh, 640px);
+            overflow-y: auto;
+            scrollbar-gutter: stable both-edges;
+            overscroll-behavior: contain;
         }
 
         #settingsDrawer h2 {
@@ -506,10 +510,14 @@
         }
 
         #preflightPrompt {
-            position: relative;
-            width: 100%;
+            position: fixed;
+            top: 50%;
+            left: 50%;
+            transform: translate(-50%, -50%);
+            width: min(420px, calc(100vw - 48px));
+            max-height: min(72vh, 460px);
             margin: 0;
-            padding: clamp(16px, 4vw, 22px);
+            padding: clamp(18px, 4vw, 24px);
             border-radius: 12px;
             border: 4px solid #f4f4f4;
             background: linear-gradient(180deg, #161616 0%, #111 100%);
@@ -524,15 +532,19 @@
             text-transform: uppercase;
             text-align: center;
             display: grid;
-            gap: clamp(10px, 2vw, 16px);
+            gap: clamp(12px, 2.4vw, 18px);
             justify-items: center;
             pointer-events: auto;
+            overflow-y: auto;
+            scrollbar-gutter: stable both-edges;
+            overscroll-behavior: contain;
+            z-index: 70;
         }
 
         #preflightPrompt::after {
             content: "";
             position: absolute;
-            inset: clamp(6px, 1.8vw, 8px);
+            inset: clamp(8px, 2.1vw, 12px);
             border: 2px solid rgba(255, 255, 255, 0.12);
             z-index: 0;
             pointer-events: none;
@@ -558,6 +570,8 @@
 
         #preflightPrompt .prompt-text {
             text-shadow: 0 2px 0 rgba(0, 0, 0, 0.7);
+            width: 100%;
+            max-width: 32ch;
         }
 
         #preflightPrompt[hidden] {
@@ -594,6 +608,17 @@
 
         body.touch-enabled #preflightPrompt .desktop-only {
             display: none;
+        }
+
+        @media (max-width: 520px) {
+            #preflightPrompt {
+                width: calc(100vw - 32px);
+                max-height: calc(100vh - 32px);
+            }
+
+            #preflightPrompt::after {
+                inset: clamp(6px, 3vw, 10px);
+            }
         }
 
         #settingsHint {
@@ -1217,6 +1242,8 @@
             transition: opacity 200ms ease;
             z-index: 4;
             overflow-y: auto;
+            scrollbar-gutter: stable both-edges;
+            overscroll-behavior: contain;
         }
 
         #overlay.hidden {
@@ -1439,6 +1466,10 @@
             flex-direction: column;
             align-items: center;
             gap: clamp(16px, 3vw, 28px);
+            max-height: min(90vh, 720px);
+            overflow-y: auto;
+            scrollbar-gutter: stable both-edges;
+            overscroll-behavior: contain;
         }
 
         #characterSelectModal h2 {
@@ -1452,9 +1483,17 @@
         #characterSelectSummary {
             margin: 0;
             font-size: clamp(0.72rem, 1.9vw, 0.9rem);
+            width: min(72ch, 100%);
             max-width: 72ch;
             text-align: center;
             color: rgba(191, 219, 254, 0.86);
+            line-height: 1.5;
+            min-height: clamp(64px, 12vh, 96px);
+            max-height: clamp(120px, 24vh, 160px);
+            overflow-y: auto;
+            scrollbar-gutter: stable both-edges;
+            overscroll-behavior: contain;
+            padding-right: clamp(0px, 1vw, 10px);
         }
 
         .character-grid {
@@ -1901,7 +1940,8 @@
             }
 
             #preflightPrompt {
-                width: 100%;
+                width: min(420px, calc(100vw - 32px));
+                max-width: min(420px, calc(100vw - 32px));
                 border-width: 3px;
                 box-shadow:
                     0 0 0 6px #202020,


### PR DESCRIPTION
## Summary
- center the preflight prompt as a fixed-size overlay with viewport-aware sizing and internal scrolling so overload messaging stays contained
- add scrollable, capped-height containers to modals such as the settings drawer, mission overlay, and character selection summary to prevent layout expansion when text changes

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68cefb9ab4648324a79358c58f0dfc93