### PR TITLE
Refine overlay layout and rename intro title

### DIFF
--- a/index.html
+++ b/index.html
@@ -187,8 +187,9 @@
         <button id="fireButton" type="button" aria-label="Fire cosmic arrows">Fire</button>
     </div>
     <div id="overlay">
-        <h1>NYAN ESCAPE</h1>
-        <div id="comicIntro" class="comic-panels" hidden>
+        <div class="overlay-content">
+            <h1>NYAN DASH</h1>
+            <div id="comicIntro" class="comic-panels" hidden>
             <article class="comic-panel">
                 <h3>Inciting Incident</h3>
                 <p>Space Station Meowprise is under siege by neon asteroids. Only your star-kitted reflexes can cut a path to safety.</p>
@@ -202,61 +203,62 @@
                 <p>Every logged flight inspires the squadron. Chronicle your best three runs each cycle and rally the galaxy.</p>
             </article>
         </div>
-        <p id="overlayMessage">Thread the cosmic needle, gather Points, and charge Nova Pulses to vaporize space junk. Ready to glide?</p>
-        <form id="callsignForm" autocomplete="off" novalidate>
-            <label for="playerNameInput">Pilot Callsign</label>
-            <div class="input-row">
-                <input id="playerNameInput" name="playerName" type="text" maxlength="24" autocomplete="off" spellcheck="false" placeholder="Ace Pilot" aria-describedby="callsignHint">
-                <span id="callsignHint">Confirm your callsign, then press Start (Enter) to launch.</span>
-            </div>
-        </form>
-        <div id="overlayActions">
-            <button id="overlayButton" type="button" disabled aria-disabled="true">Confirm Callsign</button>
-            <button id="overlaySecondaryButton" type="button" class="secondary" hidden aria-disabled="true">Skip Submission</button>
-        </div>
-        <div id="overlayPanels">
-            <div id="highScorePanel">
-                <div id="highScoreTitle">Top Flight Times</div>
-                <ol id="highScoreList"></ol>
-            </div>
-            <div id="leaderboardPanel">
-                <div class="panel-header">
-                    <div class="panel-title" id="leaderboardTitle">Galaxy Standings</div>
-                    <div class="panel-tabs" role="tablist" aria-label="Leaderboard scope">
-                        <button
-                            type="button"
-                            class="leaderboard-tab active"
-                            data-leaderboard-scope="global"
-                            aria-pressed="true"
-                        >
-                            Global
-                        </button>
-                        <button
-                            type="button"
-                            class="leaderboard-tab"
-                            data-leaderboard-scope="weekly"
-                            aria-pressed="false"
-                        >
-                            Weekly
-                        </button>
-                    </div>
+            <p id="overlayMessage">Thread the cosmic needle, gather Points, and charge Nova Pulses to vaporize space junk. Ready to glide?</p>
+            <form id="callsignForm" autocomplete="off" novalidate>
+                <label for="playerNameInput">Pilot Callsign</label>
+                <div class="input-row">
+                    <input id="playerNameInput" name="playerName" type="text" maxlength="24" autocomplete="off" spellcheck="false" placeholder="Ace Pilot" aria-describedby="callsignHint">
+                    <span id="callsignHint">Confirm your callsign, then press Start (Enter) to launch.</span>
                 </div>
-                <p
-                    id="leaderboardStatus"
-                    class="panel-status"
-                    role="status"
-                    aria-live="polite"
-                    hidden
-                ></p>
-                <ol id="leaderboardList"></ol>
+            </form>
+            <div id="overlayActions">
+                <button id="overlayButton" type="button" disabled aria-disabled="true">Confirm Callsign</button>
+                <button id="overlaySecondaryButton" type="button" class="secondary" hidden aria-disabled="true">Skip Submission</button>
             </div>
-        </div>
-        <div id="sharePanel">
-            <div class="panel-title">Broadcast Run</div>
-            <div class="share-buttons">
-                <button id="shareButton" class="share-button" type="button">Share Flight Log</button>
+            <div id="overlayPanels">
+                <div id="highScorePanel">
+                    <div id="highScoreTitle">Top Flight Times</div>
+                    <ol id="highScoreList"></ol>
+                </div>
+                <div id="leaderboardPanel">
+                    <div class="panel-header">
+                        <div class="panel-title" id="leaderboardTitle">Galaxy Standings</div>
+                        <div class="panel-tabs" role="tablist" aria-label="Leaderboard scope">
+                            <button
+                                type="button"
+                                class="leaderboard-tab active"
+                                data-leaderboard-scope="global"
+                                aria-pressed="true"
+                            >
+                                Global
+                            </button>
+                            <button
+                                type="button"
+                                class="leaderboard-tab"
+                                data-leaderboard-scope="weekly"
+                                aria-pressed="false"
+                            >
+                                Weekly
+                            </button>
+                        </div>
+                    </div>
+                    <p
+                        id="leaderboardStatus"
+                        class="panel-status"
+                        role="status"
+                        aria-live="polite"
+                        hidden
+                    ></p>
+                    <ol id="leaderboardList"></ol>
+                </div>
             </div>
-            <p id="shareStatus" role="status" aria-live="polite"></p>
+            <div id="sharePanel">
+                <div class="panel-title">Broadcast Run</div>
+                <div class="share-buttons">
+                    <button id="shareButton" class="share-button" type="button">Share Flight Log</button>
+                </div>
+                <p id="shareStatus" role="status" aria-live="polite"></p>
+            </div>
         </div>
     </div>
     <div id="characterSelectModal" hidden aria-hidden="true">

--- a/styles/main.css
+++ b/styles/main.css
@@ -1247,18 +1247,36 @@ body.touch-enabled #preflightPrompt .desktop-only {
     position: fixed;
     inset: 0;
     display: flex;
-    flex-direction: column;
     justify-content: center;
     align-items: center;
     background: linear-gradient(rgba(5, 8, 25, 0.92), rgba(1, 3, 12, 0.94));
-    text-align: center;
-    padding: clamp(32px, 6vw, 64px);
-    gap: clamp(14px, 3vw, 24px);
+    padding: clamp(18px, 4vw, 54px);
     transition: opacity 200ms ease;
     z-index: 4;
     overflow-y: auto;
     scrollbar-gutter: stable both-edges;
     overscroll-behavior: contain;
+}
+
+.overlay-content {
+    position: relative;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: clamp(14px, 3vw, 24px);
+    padding: clamp(24px, 5vw, 48px);
+    width: min(720px, 92vw);
+    max-height: min(92vh, 720px);
+    overflow-y: auto;
+    scrollbar-gutter: stable both-edges;
+    background: linear-gradient(155deg, rgba(8, 15, 35, 0.95), rgba(2, 6, 23, 0.9));
+    border-radius: 28px;
+    box-shadow:
+        0 32px 64px rgba(2, 6, 23, 0.65),
+        inset 0 0 0 1px rgba(56, 189, 248, 0.18);
+    text-align: center;
+    backdrop-filter: blur(12px);
+    -webkit-backdrop-filter: blur(12px);
 }
 
 #overlay.hidden {
@@ -1381,7 +1399,7 @@ body.touch-enabled #preflightPrompt .desktop-only {
 #overlay p {
     margin: 0;
     font-size: 0.78rem;
-    max-width: min(420px, 90vw);
+    max-width: min(480px, 100%);
     color: rgba(224, 231, 255, 0.88);
     white-space: pre-line;
 }
@@ -1391,7 +1409,7 @@ body.touch-enabled #preflightPrompt .desktop-only {
     flex-direction: column;
     align-items: stretch;
     gap: 10px;
-    width: min(360px, 90vw);
+    width: min(360px, 100%);
 }
 
 #overlayActions button {


### PR DESCRIPTION
## Summary
- introduce a dedicated overlay content container that mirrors the sleeker card treatment used by the character select screen
- constrain and restyle the overlay elements for improved spacing and scrolling on smaller viewports
- rename the intro heading from “NYAN ESCAPE” to “NYAN DASH”

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cf04d229908324b3006a41b81599f3