### PR TITLE
Improve pilot selection UI and data

### DIFF
--- a/index.html
+++ b/index.html
@@ -374,51 +374,14 @@
             aria-labelledby="characterSelectTitle"
         >
             <h2 id="characterSelectTitle">Select Your Pilot</h2>
-            <p id="characterSelectSummary">
-                Each pilot tunes the starfighter differently. Hover or focus to reveal their loadout, then lock in the
-                approach that fits this run.
-            </p>
-            <div class="character-grid" role="list">
-                <button type="button" class="character-card" data-character-id="nova" role="listitem">
-                    <img src="assets/player.png" alt="Nova Navigator" loading="lazy" />
-                    <div class="character-name">Nova Navigator</div>
-                    <div class="character-role">Balanced Ace</div>
-                    <div class="character-details">
-                        <strong>Flight Profile</strong>
-                        <ul>
-                            <li>Factory-tuned thrusters for adaptable handling.</li>
-                            <li>Even dash burst and recovery for reliable escapes.</li>
-                            <li>Baseline plasma cadence ready for any mission.</li>
-                        </ul>
-                    </div>
-                </button>
-                <button type="button" class="character-card" data-character-id="comet" role="listitem">
-                    <img src="assets/player2.png" alt="Comet Vanguard" loading="lazy" />
-                    <div class="character-name">Comet Vanguard</div>
-                    <div class="character-role">Speed Specialist</div>
-                    <div class="character-details">
-                        <strong>Flight Profile</strong>
-                        <ul>
-                            <li>High-output engines spike acceleration and top speed.</li>
-                            <li>Shorter dash cooldown built for aggressive weaving.</li>
-                            <li>Rapid-fire bolts keep pressure on debris clusters.</li>
-                        </ul>
-                    </div>
-                </button>
-                <button type="button" class="character-card" data-character-id="nebula" role="listitem">
-                    <img src="assets/player3.png" alt="Nebula Warden" loading="lazy" />
-                    <div class="character-name">Nebula Warden</div>
-                    <div class="character-role">Shielded Scout</div>
-                    <div class="character-details">
-                        <strong>Flight Profile</strong>
-                        <ul>
-                            <li>Compact hull trims the hitbox for precision dodges.</li>
-                            <li>Extended dash window excels at sustained evasions.</li>
-                            <li>Heavy plasma rounds punch through asteroid armor.</li>
-                        </ul>
-                    </div>
-                </button>
+            <div id="characterSelectSummary" aria-live="polite">
+                <p class="character-summary-description" data-character-summary-description>
+                    Each pilot tunes the starfighter differently. Hover or focus to reveal their loadout, then lock in
+                    the approach that fits this run.
+                </p>
+                <ul class="character-summary-ongoing" data-character-summary-ongoing hidden></ul>
             </div>
+            <div class="character-grid" role="list" data-character-grid></div>
             <div class="character-select-actions">
                 <button id="characterSelectConfirm" type="button" disabled aria-disabled="true">
                     Select a Pilot

--- a/styles/main.css
+++ b/styles/main.css
@@ -1531,19 +1531,44 @@ body.character-select-open {
 }
 
 #characterSelectSummary {
-    margin: 0;
-    font-size: clamp(0.72rem, 1.9vw, 0.9rem);
     width: min(72ch, 100%);
     max-width: 72ch;
-    text-align: center;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: clamp(10px, 2.4vw, 16px);
     color: rgba(191, 219, 254, 0.86);
     line-height: 1.5;
-    min-height: clamp(64px, 12vh, 96px);
-    max-height: clamp(120px, 24vh, 160px);
+    min-height: clamp(64px, 12vh, 108px);
+    max-height: clamp(140px, 26vh, 188px);
     overflow-y: auto;
+    text-align: center;
     scrollbar-gutter: stable both-edges;
     overscroll-behavior: contain;
     padding-right: clamp(0px, 1vw, 10px);
+}
+
+#characterSelectSummary .character-summary-description {
+    margin: 0;
+    font-size: clamp(0.72rem, 1.9vw, 0.9rem);
+}
+
+#characterSelectSummary .character-summary-ongoing {
+    width: 100%;
+    margin: 0;
+    padding: 0 0 0 1.25em;
+    list-style: disc;
+    text-align: left;
+    font-size: clamp(0.68rem, 1.7vw, 0.82rem);
+    color: rgba(226, 232, 240, 0.92);
+}
+
+#characterSelectSummary .character-summary-ongoing li {
+    margin-bottom: 0.35em;
+}
+
+#characterSelectSummary .character-summary-ongoing[hidden] {
+    display: none;
 }
 
 .character-grid {


### PR DESCRIPTION
## Summary
- render pilot selection cards from the shared character profile definitions to keep the modal in sync with game logic
- surface each pilot's ongoing loadout notes inside the modal summary while refreshing the preview card visuals
- adjust selection styles to support the expanded summary layout

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68cf0bd5ddbc8324add6ebca7ce89970