### PR TITLE
Ensure swap pilot opens character select

### DIFF
--- a/scripts/app.js
+++ b/scripts/app.js
@@ -5597,6 +5597,17 @@ document.addEventListener('DOMContentLoaded', () => {
         return Boolean(characterSelectModal && characterSelectModal.hidden === false);
     }
 
+    function resolveCharacterSelectAction() {
+        const overlayMode = overlayButton?.dataset.launchMode;
+        if (overlayMode === 'retry') {
+            return 'retry';
+        }
+        if (overlayMode === 'launch') {
+            return 'launch';
+        }
+        return state.gameState === 'ready' ? 'launch' : 'retry';
+    }
+
     function openCharacterSelect(action) {
         if (!characterSelectModal) {
             if (action === 'retry') {
@@ -5658,7 +5669,7 @@ document.addEventListener('DOMContentLoaded', () => {
             if (swapPilotButton.disabled) {
                 return;
             }
-            openCharacterSelect('launch');
+            openCharacterSelect(resolveCharacterSelectAction());
         });
     }
     if (pilotPreviewGrid) {
@@ -5671,7 +5682,7 @@ document.addEventListener('DOMContentLoaded', () => {
             if (!characterId || !characterSelectModal) {
                 return;
             }
-            openCharacterSelect('launch');
+            openCharacterSelect(resolveCharacterSelectAction());
             setPendingCharacter(characterId, { focusCard: true });
         });
     }


### PR DESCRIPTION
## Summary
- derive the pilot selection action from the current overlay launch mode
- route Swap Pilot and preview card clicks through the resolver so the modal always opens with the right context

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cf0f45157083248af32a8b9c9ac0a6