### PR TITLE
Add preflight pilot swap control

### DIFF
--- a/index.html
+++ b/index.html
@@ -43,6 +43,16 @@
                     <span class="hud-title" aria-hidden="true">Nyan Ready</span>
                     <span class="prompt-text desktop-only">Press Start (Enter) to launch</span>
                     <button id="mobilePreflightButton" type="button" hidden aria-hidden="true">Tap Start</button>
+                    <button
+                        id="preflightSwapPilotButton"
+                        type="button"
+                        class="tertiary"
+                        hidden
+                        aria-hidden="true"
+                        aria-disabled="true"
+                    >
+                        Swap Pilot
+                    </button>
                 </div>
                 <div id="settingsHint" aria-live="polite">
                     <span class="desktop-only">Press Esc for settings</span>

--- a/scripts/app.js
+++ b/scripts/app.js
@@ -910,6 +910,7 @@ document.addEventListener('DOMContentLoaded', () => {
     const runSummaryPlacementEl = document.getElementById('runSummaryPlacement');
     const runSummaryRunsEl = document.getElementById('runSummaryRuns');
     const swapPilotButton = document.getElementById('swapPilotButton');
+    const preflightSwapPilotButton = document.getElementById('preflightSwapPilotButton');
     const pilotPreviewGrid = document.getElementById('pilotPreviewGrid');
     const shareButton = document.getElementById('shareButton');
     const shareStatusEl = document.getElementById('shareStatus');
@@ -5274,19 +5275,27 @@ document.addEventListener('DOMContentLoaded', () => {
     }
 
     function updateSwapPilotButton() {
-        if (!swapPilotButton) {
-            return;
-        }
         const profile = getCharacterProfile(activeCharacterId);
         const label = profile ? `Swap Pilot (${profile.name})` : 'Swap Pilot';
-        swapPilotButton.textContent = label;
-        swapPilotButton.setAttribute('aria-label', profile ? `Swap pilot — current ${profile.name}` : 'Swap pilot');
-        if (!characterSelectModal) {
-            swapPilotButton.disabled = true;
-            swapPilotButton.setAttribute('aria-disabled', 'true');
-        } else {
-            swapPilotButton.disabled = false;
-            swapPilotButton.setAttribute('aria-disabled', 'false');
+        const ariaLabel = profile ? `Swap pilot — current ${profile.name}` : 'Swap pilot';
+        const canSelectPilot = Boolean(characterSelectModal);
+        if (swapPilotButton) {
+            swapPilotButton.textContent = label;
+            swapPilotButton.setAttribute('aria-label', ariaLabel);
+            if (!canSelectPilot) {
+                swapPilotButton.disabled = true;
+                swapPilotButton.setAttribute('aria-disabled', 'true');
+            } else {
+                swapPilotButton.disabled = false;
+                swapPilotButton.setAttribute('aria-disabled', 'false');
+            }
+        }
+        if (preflightSwapPilotButton) {
+            preflightSwapPilotButton.textContent = label;
+            preflightSwapPilotButton.setAttribute('aria-label', ariaLabel);
+            const shouldDisable = !canSelectPilot || preflightSwapPilotButton.hidden;
+            preflightSwapPilotButton.disabled = shouldDisable;
+            preflightSwapPilotButton.setAttribute('aria-disabled', shouldDisable ? 'true' : 'false');
         }
     }
 
@@ -5636,6 +5645,10 @@ document.addEventListener('DOMContentLoaded', () => {
         }
     }
 
+    function requestPilotSelection(source) {
+        openCharacterSelect(resolveCharacterSelectAction(), { source });
+    }
+
     function closeCharacterSelect() {
         if (!characterSelectModal) {
             return;
@@ -5691,7 +5704,15 @@ document.addEventListener('DOMContentLoaded', () => {
             if (swapPilotButton.disabled) {
                 return;
             }
-            openCharacterSelect(resolveCharacterSelectAction(), { source: 'swap' });
+            requestPilotSelection('swap');
+        });
+    }
+    if (preflightSwapPilotButton) {
+        preflightSwapPilotButton.addEventListener('click', () => {
+            if (preflightSwapPilotButton.disabled) {
+                return;
+            }
+            requestPilotSelection('preflight');
         });
     }
     if (pilotPreviewGrid) {
@@ -5704,7 +5725,7 @@ document.addEventListener('DOMContentLoaded', () => {
             if (!characterId || !characterSelectModal) {
                 return;
             }
-            openCharacterSelect(resolveCharacterSelectAction(), { source: 'preview' });
+            requestPilotSelection('preview');
             setPendingCharacter(characterId, { focusCard: true });
         });
     }
@@ -6861,6 +6882,14 @@ document.addEventListener('DOMContentLoaded', () => {
         if (mobilePreflightButton) {
             mobilePreflightButton.disabled = !visible || !isTouchInterface;
         }
+        if (preflightSwapPilotButton) {
+            preflightSwapPilotButton.hidden = !visible;
+            preflightSwapPilotButton.setAttribute('aria-hidden', visible ? 'false' : 'true');
+            const shouldDisable = !visible || !characterSelectModal;
+            preflightSwapPilotButton.disabled = shouldDisable;
+            preflightSwapPilotButton.setAttribute('aria-disabled', shouldDisable ? 'true' : 'false');
+        }
+        updateSwapPilotButton();
     }
 
     function showPreflightPrompt() {


### PR DESCRIPTION
## Summary
- add a Swap Pilot control to the preflight prompt so players can reopen the pilot selection modal after preparing to launch
- centralize pilot selection logic so multiple entry points use the same helper
- keep the new preflight swap button in sync with the main swap button labels and accessibility state

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cf1609b9b083248f92b62ac50362fe