### PR TITLE
Fix quick start flag initialization order

### DIFF
--- a/scripts/app.js
+++ b/scripts/app.js
@@ -3452,6 +3452,8 @@ document.addEventListener('DOMContentLoaded', () => {
         return sanitized.length >= 3 ? sanitized : 'Flight Cadet';
     }
 
+    let quickStartUsed = false;
+
     function refreshFlyNowButton() {
         if (!flyNowButton) {
             return;
@@ -3519,7 +3521,6 @@ document.addEventListener('DOMContentLoaded', () => {
     let preflightReady = false;
     let tutorialFlightActive = false;
     let tutorialCallsign = null;
-    let quickStartUsed = false;
     let activeSummaryTab = summarySections.has('run') ? 'run' : summarySections.keys().next().value ?? null;
 
     function setActiveSummaryTab(tabId, { focusTab = false } = {}) {


### PR DESCRIPTION
## Summary
- ensure the quick start usage flag is declared before functions that reference it
- prevent runtime ReferenceError during the first run experience initialization

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68cf1bbb6ba48324b95317c567862e57