### PR TITLE
Fix early initialization errors for quick start and world scaling

### DIFF
--- a/scripts/app.js
+++ b/scripts/app.js
@@ -962,6 +962,8 @@ document.addEventListener('DOMContentLoaded', () => {
 
     let debugOverlayEnabled = false;
     let player = null;
+    const stars = [];
+    const asteroids = [];
     try {
         debugOverlayEnabled = window.localStorage.getItem(DEBUG_OVERLAY_STORAGE_KEY) === '1';
     } catch {
@@ -2041,6 +2043,7 @@ document.addEventListener('DOMContentLoaded', () => {
     }
 
     let firstRunExperience = true;
+    let quickStartUsed = false;
 
     function readStorage(key) {
         if (!storageAvailable) return null;
@@ -3451,8 +3454,6 @@ document.addEventListener('DOMContentLoaded', () => {
         const sanitized = sanitizePlayerName(raw);
         return sanitized.length >= 3 ? sanitized : 'Flight Cadet';
     }
-
-    let quickStartUsed = false;
 
     function refreshFlyNowButton() {
         if (!flyNowButton) {
@@ -6026,8 +6027,6 @@ document.addEventListener('DOMContentLoaded', () => {
     const obstacles = [];
     const collectibles = [];
     const powerUps = [];
-    const stars = [];
-    const asteroids = [];
     let asteroidSpawnTimer = 0;
     const particles = [];
     const villainExplosions = [];


### PR DESCRIPTION
## Summary
- initialize quick start tracking before first use so the fly now button logic loads correctly
- define starfield and asteroid collections before viewport metrics run to avoid temporal dead zone errors

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cf1cb00be88324810d5d937d2379bf