### PR TITLE
Fix fly now button initialization

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,6 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Nyan Escape</title>
     <link rel="stylesheet" href="styles/main.css">
+    <link rel="icon" type="image/png" href="assets/logo.png">
 
 </head>
 <body>

--- a/scripts/app.js
+++ b/scripts/app.js
@@ -1,4 +1,12 @@
+let firstRunExperience = true;
+let quickStartUsed = false;
+
 document.addEventListener('DOMContentLoaded', () => {
+    // Reset onboarding flags whenever the game reinitializes. This ensures that
+    // subsequent reloads (such as during development hot-reloads) don't carry
+    // over stale values from previous executions.
+    firstRunExperience = true;
+    quickStartUsed = false;
     const canvas = document.getElementById('gameCanvas');
     const ctx = canvas?.getContext ? canvas.getContext('2d') : null;
 
@@ -2041,9 +2049,6 @@ document.addEventListener('DOMContentLoaded', () => {
     } catch (error) {
         storageAvailable = false;
     }
-
-    let firstRunExperience = true;
-    let quickStartUsed = false;
 
     function readStorage(key) {
         if (!storageAvailable) return null;


### PR DESCRIPTION
## Summary
- declare the onboarding state flags before the DOMContentLoaded handler and reset them when initializing
- add a favicon link so browsers no longer request the missing resource

## Testing
- not run (project has no automated tests)


------
https://chatgpt.com/codex/tasks/task_e_68cf1dd867908324861da6814407259c