### PR TITLE
Adjust physics timestep to precise 60Hz

### DIFF
--- a/scripts/app.js
+++ b/scripts/app.js
@@ -10538,7 +10538,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
     let lastTime = null;
     let accumulatedDelta = 0;
-    const FIXED_TIMESTEP = 16;
+    const FIXED_TIMESTEP = 1000 / 60; // Use a precise 60 Hz simulation step to avoid browser-specific rounding.
     const MAX_ACCUMULATED_TIME = FIXED_TIMESTEP * 6;
 
     function gameLoop(timestamp = performance.now()) {


### PR DESCRIPTION
## Summary
- use an exact 60 Hz fixed timestep for the main game loop to avoid browser-dependent rounding differences

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cf1ef8d05c8324af3cbabde5b9d952