### PR TITLE
Cache trail timestamp per frame

### DIFF
--- a/scripts/app.js
+++ b/scripts/app.js
@@ -9946,6 +9946,7 @@ document.addEventListener('DOMContentLoaded', () => {
         }
         if (trail.length < 2) return;
         const style = activeTrailStyle ?? trailStyles.rainbow;
+        const now = performance.now();
         ctx.save();
         if (style.type === 'palette' && Array.isArray(style.colors) && style.colors.length) {
             for (let i = 0; i < trail.length; i++) {
@@ -9960,7 +9961,7 @@ document.addEventListener('DOMContentLoaded', () => {
             for (let i = 0; i < trail.length; i++) {
                 const t = trail[i];
                 const alpha = i / trail.length;
-                const hue = (alpha * 300 + performance.now() * 0.05) % 360;
+                const hue = (alpha * 300 + now * 0.05) % 360;
                 ctx.fillStyle = `hsla(${hue}, 100%, 60%, ${alpha})`;
                 ctx.fillRect(t.x - 36, t.y - 6, 72, 12);
             }


### PR DESCRIPTION
## Summary
- cache the per-frame timestamp once in drawTrail before iterating over the trail
- reuse the cached timestamp when computing the animated fallback hue

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68cf239d24f883248248fbe7a56a9d9a