### PR TITLE
Cache background gradient

### DIFF
--- a/scripts/app.js
+++ b/scripts/app.js
@@ -981,6 +981,8 @@ document.addEventListener('DOMContentLoaded', () => {
     let pendingResizeFrame = null;
     let devicePixelRatioQuery = null;
     let resizeObserver = null;
+    let backgroundGradient = null;
+    let backgroundGradientHeight = 0;
 
     function measureElementSize(element) {
         if (!element) {
@@ -1175,6 +1177,10 @@ document.addEventListener('DOMContentLoaded', () => {
 
         viewport.width = displayWidth;
         viewport.height = displayHeight;
+        if (previousHeight !== displayHeight) {
+            backgroundGradient = null;
+            backgroundGradientHeight = 0;
+        }
         viewport.cssWidth = displayWidth;
         viewport.cssHeight = displayHeight;
         viewport.physicalWidth = physicalWidth;
@@ -9918,10 +9924,15 @@ document.addEventListener('DOMContentLoaded', () => {
     function drawBackground() {
         ctx.fillStyle = '#05091f';
         ctx.fillRect(0, 0, viewport.width, viewport.height);
-        const gradient = ctx.createLinearGradient(0, 0, 0, viewport.height);
-        gradient.addColorStop(0, 'rgba(26, 35, 126, 0.85)');
-        gradient.addColorStop(0.5, 'rgba(21, 11, 45, 0.85)');
-        gradient.addColorStop(1, 'rgba(0, 2, 12, 0.95)');
+        let gradient = backgroundGradient;
+        if (!gradient || backgroundGradientHeight !== viewport.height) {
+            gradient = ctx.createLinearGradient(0, 0, 0, viewport.height);
+            gradient.addColorStop(0, 'rgba(26, 35, 126, 0.85)');
+            gradient.addColorStop(0.5, 'rgba(21, 11, 45, 0.85)');
+            gradient.addColorStop(1, 'rgba(0, 2, 12, 0.95)');
+            backgroundGradient = gradient;
+            backgroundGradientHeight = viewport.height;
+        }
         ctx.fillStyle = gradient;
         ctx.fillRect(0, 0, viewport.width, viewport.height);
     }


### PR DESCRIPTION
## Summary
- add cached gradient state so drawBackground reuses gradients when the viewport height is unchanged
- rebuild the gradient only when the cached height differs and clear the cache when the viewport is resized

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cf239eefa8832489d2e4471a32797f