### PR TITLE
Add pause system with overlay and auto suspension

### DIFF
--- a/index.html
+++ b/index.html
@@ -56,8 +56,8 @@
                     </button>
                 </div>
                 <div id="settingsHint" aria-live="polite">
-                    <span class="desktop-only">Press Esc for settings</span>
-                    <span class="touch-only">Tap ⚙ for settings</span>
+                    <span class="desktop-only">Press Esc for settings · P pauses</span>
+                    <span class="touch-only">Tap ⚙ to pause &amp; adjust settings</span>
                 </div>
             </div>
         </div>
@@ -131,6 +131,12 @@
                                     <span class="keycap wide" aria-hidden="true">Space</span>
                                 </div>
                                 <div class="control-action">Launch precision plasma bolts.</div>
+                            </div>
+                            <div class="control-row" role="listitem">
+                                <div class="control-keys" aria-label="Pause control">
+                                    <span class="keycap wide" aria-hidden="true">P</span>
+                                </div>
+                                <div class="control-action">Pause or resume the flight deck.</div>
                             </div>
                             <div class="control-row" role="listitem">
                                 <div class="control-keys" aria-label="Settings shortcut">
@@ -473,6 +479,24 @@
                     </label>
                 </div>
             </div>
+        </div>
+    </div>
+    <div
+        id="pauseOverlay"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="pauseTitle"
+        aria-hidden="true"
+        hidden
+    >
+        <div class="pause-card" role="document">
+            <h2 id="pauseTitle">Flight Paused</h2>
+            <p id="pauseMessage">Press P or tap Resume to continue your run.</p>
+            <div class="pause-actions">
+                <button id="resumeButton" type="button" class="pause-primary">Resume</button>
+                <button id="pauseSettingsButton" type="button" class="pause-secondary">Settings</button>
+            </div>
+            <p id="pauseHint" class="pause-hint" hidden></p>
         </div>
     </div>
 

--- a/styles/main.css
+++ b/styles/main.css
@@ -520,6 +520,17 @@ canvas {
     pointer-events: none;
 }
 
+#survivalTimer.paused {
+    background: rgba(30, 64, 175, 0.85);
+    box-shadow:
+        0 10px 24px rgba(30, 64, 175, 0.35),
+        0 0 0 1px rgba(191, 219, 254, 0.28);
+}
+
+#survivalTimer.paused .value {
+    color: #fde68a;
+}
+
 #survivalTimer .value {
     color: #7dd3fc;
 }
@@ -1243,7 +1254,7 @@ body.touch-enabled #preflightPrompt .desktop-only {
     box-shadow: 0 12px 28px rgba(255, 64, 129, 0.35);
 }
 
-#overlay {
+#overlay { 
     position: fixed;
     inset: 0;
     display: flex;
@@ -1256,6 +1267,106 @@ body.touch-enabled #preflightPrompt .desktop-only {
     overflow-y: auto;
     scrollbar-gutter: stable both-edges;
     overscroll-behavior: contain;
+}
+
+#pauseOverlay {
+    position: fixed;
+    inset: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: clamp(18px, 4vw, 48px);
+    background: rgba(6, 11, 25, 0.74);
+    backdrop-filter: blur(10px);
+    -webkit-backdrop-filter: blur(10px);
+    z-index: 12;
+    transition: opacity 180ms ease;
+}
+
+#pauseOverlay[hidden] {
+    display: none;
+}
+
+#pauseOverlay .pause-card {
+    width: min(420px, 92vw);
+    padding: clamp(22px, 5vw, 36px);
+    border-radius: 24px;
+    background: linear-gradient(160deg, rgba(15, 23, 42, 0.95), rgba(30, 41, 59, 0.9));
+    box-shadow:
+        0 28px 56px rgba(2, 6, 23, 0.58),
+        inset 0 0 0 1px rgba(96, 165, 250, 0.22);
+    color: #e2e8f0;
+    text-align: center;
+    display: flex;
+    flex-direction: column;
+    gap: clamp(16px, 3vw, 24px);
+}
+
+#pauseOverlay .pause-card h2 {
+    margin: 0;
+    font-size: clamp(1.4rem, 4.2vw, 2.2rem);
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+    color: #bfdbfe;
+}
+
+#pauseOverlay .pause-card p {
+    margin: 0;
+    line-height: 1.5;
+}
+
+#pauseOverlay .pause-actions {
+    display: flex;
+    justify-content: center;
+    gap: 12px;
+    flex-wrap: wrap;
+}
+
+#pauseOverlay .pause-actions button {
+    border: none;
+    border-radius: 999px;
+    font-size: 0.9rem;
+    font-weight: 600;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    padding: 12px 24px;
+    cursor: pointer;
+    transition: transform 160ms ease, box-shadow 160ms ease, opacity 160ms ease;
+}
+
+#pauseOverlay .pause-primary {
+    background: linear-gradient(135deg, rgba(59, 130, 246, 0.95), rgba(56, 189, 248, 0.92));
+    color: #0f172a;
+    box-shadow: 0 18px 32px rgba(56, 189, 248, 0.35);
+}
+
+#pauseOverlay .pause-primary:hover {
+    transform: translateY(-1px);
+    box-shadow: 0 22px 38px rgba(56, 189, 248, 0.42);
+}
+
+#pauseOverlay .pause-primary:active {
+    transform: translateY(2px) scale(0.98);
+}
+
+#pauseOverlay .pause-secondary {
+    background: transparent;
+    color: #bfdbfe;
+    border: 1px solid rgba(191, 219, 254, 0.45);
+    box-shadow: 0 0 0 1px rgba(191, 219, 254, 0.25);
+}
+
+#pauseOverlay .pause-secondary:hover {
+    opacity: 0.85;
+}
+
+#pauseOverlay .pause-secondary:active {
+    transform: translateY(1px) scale(0.99);
+}
+
+#pauseOverlay .pause-hint {
+    font-size: 0.85rem;
+    color: rgba(191, 219, 254, 0.85);
 }
 
 .overlay-content {


### PR DESCRIPTION
## Summary
- add a dedicated pause/resume overlay with refreshed control instructions
- wire a new paused game state into the loop, timer, audio, and settings drawer flow
- style the pause UI and timer badge to highlight when the flight is suspended

## Testing
- not run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68cf5cde42fc8324bf2154d5c8b43a26