### PR TITLE
Fix early interaction hint init crash

### DIFF
--- a/scripts/app.js
+++ b/scripts/app.js
@@ -1,5 +1,6 @@
 let firstRunExperience = true;
 let quickStartUsed = false;
+let state = { gameState: 'ready' };
 
 document.addEventListener('DOMContentLoaded', () => {
     // Reset onboarding flags whenever the game reinitializes. This ensures that
@@ -6061,7 +6062,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
     const totalCollectibleWeight = collectibleTiers.reduce((sum, tier) => sum + tier.weight, 0);
 
-    const state = {
+    state = {
         score: 0,
         nyan: 0,
         streak: 0,


### PR DESCRIPTION
## Summary
- ensure the shared game state object exists before the interaction hint logic runs
- assign the fully populated game state later without redeclaration so the existing logic keeps working

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cf759feb2883249749112cdf2c967d