### PR TITLE
Fix gamepad cursor bounds initialization

### DIFF
--- a/scripts/app.js
+++ b/scripts/app.js
@@ -7,6 +7,7 @@ let baseDashConfig = null;
 let baseProjectileSettings = null;
 let activeDifficultyPreset = 'medium';
 let spawnTimers = { obstacle: 0, collectible: 0, powerUp: 0 };
+const GAMEPAD_CURSOR_HALF_SIZE = 11;
 
 document.addEventListener('DOMContentLoaded', () => {
     // Reset onboarding flags whenever the game reinitializes. This ensures that
@@ -1041,7 +1042,6 @@ document.addEventListener('DOMContentLoaded', () => {
     const TOUCH_SMOOTHING_RATE = 26;
     const DEBUG_OVERLAY_STORAGE_KEY = 'nyanEscape.debugOverlay';
     const TARGET_ASPECT_RATIO = 3 / 2;
-    const GAMEPAD_CURSOR_HALF_SIZE = 11;
     const viewport = {
         width: 900,
         height: 600,


### PR DESCRIPTION
## Summary
- define GAMEPAD_CURSOR_HALF_SIZE at the module scope so it is available before the viewport logic runs
- prevent the gamepad cursor bounds calculation from throwing during initialization

## Testing
- no tests were run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cfb8961ba483249025526ae1ba9d23