### PR TITLE
Fix gamepad cursor init order

### DIFF
--- a/scripts/app.js
+++ b/scripts/app.js
@@ -7,9 +7,9 @@ let baseDashConfig = null;
 let baseProjectileSettings = null;
 let activeDifficultyPreset = 'medium';
 let spawnTimers = { obstacle: 0, collectible: 0, powerUp: 0 };
-const GAMEPAD_CURSOR_HALF_SIZE = 11;
 
 document.addEventListener('DOMContentLoaded', () => {
+    const GAMEPAD_CURSOR_HALF_SIZE = 11;
     // Reset onboarding flags whenever the game reinitializes. This ensures that
     // subsequent reloads (such as during development hot-reloads) don't carry
     // over stale values from previous executions.


### PR DESCRIPTION
## Summary
- move the GAMEPAD_CURSOR_HALF_SIZE constant inside the DOMContentLoaded handler so it is initialized before refreshGamepadCursorBounds runs

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cfb99bedf883249e0d7b0d38707020