### PR TITLE
Fix gamepad cursor bounds initialization

### DIFF
--- a/scripts/app.js
+++ b/scripts/app.js
@@ -18,6 +18,7 @@ document.addEventListener('DOMContentLoaded', () => {
     const canvas = document.getElementById('gameCanvas');
     const ctx = canvas?.getContext ? canvas.getContext('2d') : null;
     const controllerCursorEl = document.getElementById('controllerCursor');
+    const gamepadCursorBounds = { left: 0, top: 0, right: 0, bottom: 0 };
 
     const supportsResizeObserver =
         typeof window !== 'undefined' && typeof window.ResizeObserver === 'function';
@@ -6536,7 +6537,6 @@ document.addEventListener('DOMContentLoaded', () => {
         pointerDownTarget: null,
         buttonHeld: false
     };
-    let gamepadCursorBounds = { left: 0, top: 0, right: 0, bottom: 0 };
     const previousGamepadButtons = [];
     const previousGamepadDirection = { x: 0, y: 0 };
     let activeGamepadIndex = null;


### PR DESCRIPTION
## Summary
- initialize `gamepadCursorBounds` before the first viewport update
- ensure the controller cursor bounds object exists when refresh runs

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cfba86b2988324a3fee688087395fb