### PR TITLE
Fix cosmetic equip menu

### DIFF
--- a/scripts/app.js
+++ b/scripts/app.js
@@ -3476,30 +3476,30 @@ document.addEventListener('DOMContentLoaded', () => {
                 }
                 if (cosmetics?.skins && !cosmetics.skins[id]) {
                     return false;
-            }
-            state.cosmetics.equipped.skin = id;
-            mutated = true;
-        } else if (category === 'trail') {
-            if (!state.cosmetics.ownedTrails.includes(id) || state.cosmetics.equipped.trail === id) {
+                }
+                state.cosmetics.equipped.skin = id;
+                mutated = true;
+            } else if (category === 'trail') {
+                if (!state.cosmetics.ownedTrails.includes(id) || state.cosmetics.equipped.trail === id) {
+                    return false;
+                }
+                if (cosmetics?.trails && !cosmetics.trails[id]) {
+                    return false;
+                }
+                state.cosmetics.equipped.trail = id;
+                mutated = true;
+            } else if (category === 'weapon') {
+                if (!state.cosmetics.ownedWeapons.includes(id) || state.cosmetics.equipped.weapon === id) {
+                    return false;
+                }
+                if (cosmetics?.weapons && !cosmetics.weapons[id]) {
+                    return false;
+                }
+                state.cosmetics.equipped.weapon = id;
+                mutated = true;
+            } else {
                 return false;
             }
-            if (cosmetics?.trails && !cosmetics.trails[id]) {
-                return false;
-            }
-            state.cosmetics.equipped.trail = id;
-            mutated = true;
-        } else if (category === 'weapon') {
-            if (!state.cosmetics.ownedWeapons.includes(id) || state.cosmetics.equipped.weapon === id) {
-                return false;
-            }
-            if (cosmetics?.weapons && !cosmetics.weapons[id]) {
-                return false;
-            }
-            state.cosmetics.equipped.weapon = id;
-            mutated = true;
-        } else {
-            return false;
-        }
             if (mutated) {
                 commitState({ notify: true });
             }


### PR DESCRIPTION
## Summary
- close the skin selection block properly in the challenge manager
- ensure trail and weapon branches are evaluated for their own categories
- allow players to equip any owned cosmetic reward again

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cfcc7685e483248de6be95c31b5525