### PR TITLE
Add modal-based weapon selection with new assets

### DIFF
--- a/assets/weapon-lance.svg
+++ b/assets/weapon-lance.svg
@@ -1,0 +1,24 @@
+<svg width="160" height="160" viewBox="0 0 160 160" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="title desc">
+  <title id="title">Star Lance icon</title>
+  <desc id="desc">Bright teal lance symbolizing the focused beam weapon.</desc>
+  <defs>
+    <linearGradient id="lanceGradient" x1="50%" y1="0%" x2="50%" y2="100%">
+      <stop offset="0%" stop-color="#bfdbfe" />
+      <stop offset="50%" stop-color="#38bdf8" />
+      <stop offset="100%" stop-color="#0ea5e9" />
+    </linearGradient>
+    <filter id="lanceGlow" x="-15%" y="-15%" width="130%" height="130%">
+      <feGaussianBlur in="SourceGraphic" stdDeviation="7" result="blur" />
+      <feMerge>
+        <feMergeNode in="blur" />
+        <feMergeNode in="SourceGraphic" />
+      </feMerge>
+    </filter>
+  </defs>
+  <rect x="0" y="0" width="160" height="160" rx="24" fill="#071229" opacity="0.95" />
+  <g filter="url(#lanceGlow)">
+    <path d="M80 20L108 64H92L124 108L80 140L36 108L68 64H52L80 20Z" fill="url(#lanceGradient)" opacity="0.92" />
+    <path d="M80 44L96 68H88L108 96L80 116L52 96L72 68H64L80 44Z" fill="#e0f2fe" opacity="0.55" />
+  </g>
+  <circle cx="80" cy="80" r="10" fill="#bae6fd" opacity="0.75" />
+</svg>

--- a/assets/weapon-pulse.svg
+++ b/assets/weapon-pulse.svg
@@ -1,0 +1,25 @@
+<svg width="160" height="160" viewBox="0 0 160 160" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="title desc">
+  <title id="title">Pulse Blaster icon</title>
+  <desc id="desc">Stylized blue plasma bolt representing the pulse weapon.</desc>
+  <defs>
+    <linearGradient id="pulseGradient" x1="0%" x2="100%" y1="50%" y2="50%">
+      <stop offset="0%" stop-color="#38bdf8" />
+      <stop offset="50%" stop-color="#60a5fa" />
+      <stop offset="100%" stop-color="#a855f7" />
+    </linearGradient>
+    <filter id="pulseGlow" x="-20%" y="-20%" width="140%" height="140%">
+      <feGaussianBlur in="SourceGraphic" stdDeviation="6" result="blur" />
+      <feMerge>
+        <feMergeNode in="blur" />
+        <feMergeNode in="SourceGraphic" />
+      </feMerge>
+    </filter>
+  </defs>
+  <rect x="0" y="0" width="160" height="160" rx="24" fill="#0f172a" opacity="0.92" />
+  <g filter="url(#pulseGlow)">
+    <path d="M48 80L24 64L52 20C86 36 120 36 144 80C120 124 86 124 52 140L24 96L48 80Z" fill="url(#pulseGradient)" opacity="0.9" />
+    <path d="M58 80C78 62 102 62 122 80C102 98 78 98 58 80Z" fill="#e0f2fe" opacity="0.6" />
+  </g>
+  <circle cx="54" cy="80" r="10" fill="#bae6fd" opacity="0.8" />
+  <circle cx="106" cy="80" r="6" fill="#c4b5fd" opacity="0.7" />
+</svg>

--- a/assets/weapon-scatter.svg
+++ b/assets/weapon-scatter.svg
@@ -1,0 +1,28 @@
+<svg width="160" height="160" viewBox="0 0 160 160" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="title desc">
+  <title id="title">Scatter Burst icon</title>
+  <desc id="desc">Two ember bolts diverging to illustrate the scatter weapon.</desc>
+  <defs>
+    <linearGradient id="scatterGradientA" x1="0%" y1="50%" x2="100%" y2="50%">
+      <stop offset="0%" stop-color="#fb923c" />
+      <stop offset="100%" stop-color="#facc15" />
+    </linearGradient>
+    <linearGradient id="scatterGradientB" x1="0%" y1="50%" x2="100%" y2="50%">
+      <stop offset="0%" stop-color="#f97316" />
+      <stop offset="100%" stop-color="#fbbf24" />
+    </linearGradient>
+    <filter id="scatterGlow" x="-15%" y="-15%" width="130%" height="130%">
+      <feGaussianBlur in="SourceGraphic" stdDeviation="5" result="blur" />
+      <feMerge>
+        <feMergeNode in="blur" />
+        <feMergeNode in="SourceGraphic" />
+      </feMerge>
+    </filter>
+  </defs>
+  <rect x="0" y="0" width="160" height="160" rx="24" fill="#1b0f23" opacity="0.95" />
+  <g filter="url(#scatterGlow)">
+    <path d="M30 118L64 80L30 42L74 22L112 80L74 138Z" fill="url(#scatterGradientA)" opacity="0.9" />
+    <path d="M130 118L96 80L130 42L86 22L48 80L86 138Z" fill="url(#scatterGradientB)" opacity="0.75" />
+  </g>
+  <circle cx="40" cy="80" r="8" fill="#fff7ed" opacity="0.7" />
+  <circle cx="120" cy="80" r="8" fill="#fff1c7" opacity="0.7" />
+</svg>

--- a/index.html
+++ b/index.html
@@ -55,6 +55,16 @@
                     >
                         Swap Pilot
                     </button>
+                    <button
+                        id="preflightSwapWeaponButton"
+                        type="button"
+                        class="tertiary"
+                        hidden
+                        aria-hidden="true"
+                        aria-disabled="true"
+                    >
+                        Swap Weapon
+                    </button>
                 </div>
                 <div id="settingsHint" aria-live="polite">
                     <span class="desktop-only">Press Esc for settings · P pauses</span>
@@ -201,7 +211,22 @@
                             </div>
                             <div class="cosmetic-group" role="group" aria-label="Weapon systems">
                                 <span class="cosmetic-group-label">Weapon</span>
-                                <div class="cosmetic-options" id="weaponOptions"></div>
+                                <div class="cosmetic-options weapon-options" id="weaponOptions">
+                                    <div class="weapon-summary-card" aria-live="polite">
+                                        <img id="weaponSummaryImage" alt="" />
+                                        <div class="weapon-summary-copy">
+                                            <span id="weaponSummaryName" class="weapon-summary-name"></span>
+                                            <p id="weaponSummaryDescription" class="weapon-summary-description"></p>
+                                        </div>
+                                    </div>
+                                    <button
+                                        id="openWeaponSelectButton"
+                                        type="button"
+                                        class="cosmetic-option weapon-change-button"
+                                    >
+                                        Change Weapon
+                                    </button>
+                                </div>
                             </div>
                         </div>
                         <ul class="intel-log" id="intelLog" role="list" aria-live="polite"></ul>
@@ -262,6 +287,7 @@
                 <button id="overlayButton" type="button" disabled aria-disabled="true">Confirm Callsign</button>
                 <button id="overlaySecondaryButton" type="button" class="secondary" hidden aria-disabled="true">Skip Submission</button>
                 <button id="swapPilotButton" type="button" class="tertiary">Swap Pilot</button>
+                <button id="swapWeaponButton" type="button" class="tertiary">Swap Weapon</button>
             </div>
             <div id="pilotPreview" aria-live="polite">
                 <div class="pilot-preview-header">
@@ -434,6 +460,28 @@
                     Select a Pilot
                 </button>
                 <button id="characterSelectCancel" type="button" class="secondary">Back</button>
+            </div>
+        </div>
+    </div>
+    <div id="weaponSelectModal" hidden aria-hidden="true">
+        <div class="character-select-backdrop" aria-hidden="true"></div>
+        <div
+            class="character-select-content"
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby="weaponSelectTitle"
+        >
+            <h2 id="weaponSelectTitle">Select Weapon Loadout</h2>
+            <div id="weaponSelectSummary" aria-live="polite">
+                <p class="character-summary-description" data-weapon-summary-description>
+                    Weapons calibrate your firing pattern. Preview each loadout, then deploy the arsenal that fits your flight
+                    plan.
+                </p>
+            </div>
+            <div class="character-grid" role="list" data-weapon-grid></div>
+            <div class="character-select-actions">
+                <button id="weaponSelectConfirm" type="button" disabled aria-disabled="true">Equip Weapon</button>
+                <button id="weaponSelectCancel" type="button" class="secondary">Back</button>
             </div>
         </div>
     </div>

--- a/styles/main.css
+++ b/styles/main.css
@@ -1228,6 +1228,55 @@ body.touch-enabled #preflightPrompt .desktop-only {
     gap: 8px;
 }
 
+.weapon-options {
+    flex-direction: column;
+    align-items: stretch;
+    gap: 12px;
+}
+
+.weapon-summary-card {
+    display: flex;
+    align-items: center;
+    gap: 14px;
+    padding: 12px 16px;
+    border-radius: 16px;
+    background: rgba(15, 23, 42, 0.55);
+    border: 1px solid rgba(148, 210, 255, 0.18);
+    box-shadow: inset 0 0 0 1px rgba(15, 23, 42, 0.32);
+}
+
+.weapon-summary-card img {
+    width: 72px;
+    height: 72px;
+    object-fit: contain;
+    filter: drop-shadow(0 12px 24px rgba(56, 189, 248, 0.28));
+}
+
+.weapon-summary-copy {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+}
+
+.weapon-summary-name {
+    font-size: 0.8rem;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+    color: rgba(148, 210, 255, 0.92);
+}
+
+.weapon-summary-description {
+    margin: 0;
+    font-size: 0.7rem;
+    line-height: 1.45;
+    color: rgba(226, 232, 240, 0.85);
+}
+
+.weapon-change-button {
+    align-self: flex-start;
+    padding-inline: 18px;
+}
+
 .cosmetic-option {
     border: 1px solid rgba(148, 210, 255, 0.18);
     background: rgba(15, 23, 42, 0.45);
@@ -1741,15 +1790,18 @@ body.touch-enabled #preflightPrompt .desktop-only {
     box-shadow: 0 10px 20px rgba(59, 130, 246, 0.28);
 }
 
-body.character-select-open {
+body.character-select-open,
+body.weapon-select-open {
     overflow: hidden;
 }
 
-#characterSelectModal[hidden] {
+#characterSelectModal[hidden],
+#weaponSelectModal[hidden] {
     display: none;
 }
 
-#characterSelectModal {
+#characterSelectModal,
+#weaponSelectModal {
     position: fixed;
     inset: 0;
     z-index: 8;
@@ -1759,7 +1811,8 @@ body.character-select-open {
     padding: clamp(24px, 5vw, 48px);
 }
 
-#characterSelectModal .character-select-backdrop {
+#characterSelectModal .character-select-backdrop,
+#weaponSelectModal .character-select-backdrop {
     position: absolute;
     inset: 0;
     background: radial-gradient(circle at top, rgba(15, 23, 42, 0.86), rgba(2, 6, 23, 0.94));
@@ -1767,7 +1820,8 @@ body.character-select-open {
     -webkit-backdrop-filter: blur(10px);
 }
 
-#characterSelectModal .character-select-content {
+#characterSelectModal .character-select-content,
+#weaponSelectModal .character-select-content {
     position: relative;
     width: min(960px, 92vw);
     background: linear-gradient(155deg, rgba(8, 15, 35, 0.95), rgba(2, 6, 23, 0.92));
@@ -1787,7 +1841,8 @@ body.character-select-open {
     overscroll-behavior: contain;
 }
 
-#characterSelectModal h2 {
+#characterSelectModal h2,
+#weaponSelectModal h2 {
     margin: 0;
     font-size: clamp(1.25rem, 3vw, 2.1rem);
     letter-spacing: 0.14em;
@@ -1795,7 +1850,8 @@ body.character-select-open {
     color: rgba(148, 210, 255, 0.92);
 }
 
-#characterSelectSummary {
+#characterSelectSummary,
+#weaponSelectSummary {
     width: min(72ch, 100%);
     max-width: 72ch;
     display: flex;
@@ -1813,7 +1869,8 @@ body.character-select-open {
     padding-right: clamp(0px, 1vw, 10px);
 }
 
-#characterSelectSummary .character-summary-description {
+#characterSelectSummary .character-summary-description,
+#weaponSelectSummary .character-summary-description {
     margin: 0;
     font-size: clamp(0.72rem, 1.9vw, 0.9rem);
 }
@@ -1951,7 +2008,9 @@ body.character-select-open {
 }
 
 #characterSelectConfirm,
-#characterSelectCancel {
+#characterSelectCancel,
+#weaponSelectConfirm,
+#weaponSelectCancel {
     border-radius: 999px;
     padding: 10px 22px;
     font-size: 0.72rem;
@@ -1961,7 +2020,8 @@ body.character-select-open {
     cursor: pointer;
 }
 
-#characterSelectConfirm {
+#characterSelectConfirm,
+#weaponSelectConfirm {
     border: none;
     background: linear-gradient(135deg, rgba(56, 189, 248, 0.92), rgba(99, 102, 241, 0.92));
     color: #fff;
@@ -1969,29 +2029,34 @@ body.character-select-open {
     transition: transform 160ms ease, box-shadow 160ms ease;
 }
 
-#characterSelectConfirm[disabled] {
+#characterSelectConfirm[disabled],
+#weaponSelectConfirm[disabled] {
     opacity: 0.6;
     cursor: default;
     box-shadow: none;
 }
 
-#characterSelectConfirm:not([disabled]):hover {
+#characterSelectConfirm:not([disabled]):hover,
+#weaponSelectConfirm:not([disabled]):hover {
     transform: translateY(-2px);
     box-shadow: 0 22px 44px rgba(37, 99, 235, 0.55);
 }
 
-#characterSelectConfirm:not([disabled]):active {
+#characterSelectConfirm:not([disabled]):active,
+#weaponSelectConfirm:not([disabled]):active {
     transform: translateY(1px);
     box-shadow: 0 14px 28px rgba(37, 99, 235, 0.48);
 }
 
-#characterSelectCancel {
+#characterSelectCancel,
+#weaponSelectCancel {
     border: 1px solid rgba(148, 210, 255, 0.4);
     background: transparent;
     color: rgba(226, 232, 240, 0.9);
 }
 
-#characterSelectCancel:hover {
+#characterSelectCancel:hover,
+#weaponSelectCancel:hover {
     border-color: rgba(148, 210, 255, 0.72);
     color: rgba(226, 232, 240, 1);
 }


### PR DESCRIPTION
## Summary
- add swap weapon controls and a dedicated weapon selection modal that mirrors the pilot picker
- render weapon loadout cards from game data, update selection state, and expose new inline summaries
- style the new controls and include SVG artwork for each weapon option

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68cfc9f271ac8324897bda573768aa7c