### PR TITLE
Reposition instruction buttons under gameplay and remove settings hint

### DIFF
--- a/index.html
+++ b/index.html
@@ -66,202 +66,198 @@
                         Swap Weapon
                     </button>
                 </div>
-                <div id="settingsHint" aria-live="polite">
-                    <span class="desktop-only">Press Esc for settings · P pauses</span>
-                    <span class="touch-only">Tap ⚙ to pause &amp; adjust settings</span>
-                </div>
             </div>
         </div>
-        <div id="instructions" aria-label="Flight telemetry, controls, and mission information">
-            <div
-                id="instructionButtonBar"
-                class="instruction-button-bar"
-                role="toolbar"
-                aria-label="Mission information panels"
-            >
-                <button type="button" class="instruction-button" data-panel-target="stats">Telemetry</button>
-                <button type="button" class="instruction-button" data-panel-target="controlsCard">Controls</button>
-                <button type="button" class="instruction-button" data-panel-target="missionCard">Mission</button>
-                <button type="button" class="instruction-button" data-panel-target="intelCard">Intel</button>
-                <button type="button" class="instruction-button" data-panel-target="socialCard">Feed</button>
-            </div>
-            <div id="instructionPanels" hidden aria-hidden="true">
-                <section id="stats" class="info-panel telemetry-panel" role="complementary" aria-live="polite">
-                    <h2 class="card-title">Flight Telemetry</h2>
-                    <div class="stat-list" role="presentation">
-                        <div class="stat-row">
-                            <span class="stat-label">Score</span>
-                            <span class="value" id="score">0</span>
-                        </div>
-                        <div class="stat-row">
-                            <span class="stat-label">Points</span>
-                            <span class="value" id="nyan">0</span>
-                        </div>
-                        <div class="stat-row">
-                            <span class="stat-label">Streak</span>
-                            <span class="value" id="streak">x1</span>
-                        </div>
-                        <div class="stat-row">
-                            <span class="stat-label">Best Tail</span>
-                            <span class="value" id="bestStreak">0</span>
-                        </div>
-                        <div class="stat-row">
-                            <span class="stat-label">MCAP</span>
-                            <span class="value" id="mcap">6.6K</span>
-                        </div>
-                        <div class="stat-row">
-                            <span class="stat-label">VOL</span>
-                            <span class="value" id="vol">2.8K</span>
-                        </div>
-                        <div class="stat-row">
-                            <span class="stat-label">Boosts</span>
-                            <span class="value" id="powerUps">None</span>
-                        </div>
+    </div>
+    <div id="instructions" aria-label="Flight telemetry, controls, and mission information">
+        <div
+            id="instructionButtonBar"
+            class="instruction-button-bar"
+            role="toolbar"
+            aria-label="Mission information panels"
+        >
+            <button type="button" class="instruction-button" data-panel-target="stats">Telemetry</button>
+            <button type="button" class="instruction-button" data-panel-target="controlsCard">Controls</button>
+            <button type="button" class="instruction-button" data-panel-target="missionCard">Mission</button>
+            <button type="button" class="instruction-button" data-panel-target="intelCard">Intel</button>
+            <button type="button" class="instruction-button" data-panel-target="socialCard">Feed</button>
+        </div>
+        <div id="instructionPanels" hidden aria-hidden="true">
+            <section id="stats" class="info-panel telemetry-panel" role="complementary" aria-live="polite">
+                <h2 class="card-title">Flight Telemetry</h2>
+                <div class="stat-list" role="presentation">
+                    <div class="stat-row">
+                        <span class="stat-label">Score</span>
+                        <span class="value" id="score">0</span>
                     </div>
-                    <div
-                        id="comboMeter"
-                        role="progressbar"
-                        aria-label="Combo charge"
-                        aria-valuemin="0"
-                        aria-valuemax="100"
-                        aria-valuenow="0"
-                    >
-                        <div id="comboFill"></div>
+                    <div class="stat-row">
+                        <span class="stat-label">Points</span>
+                        <span class="value" id="nyan">0</span>
                     </div>
-                </section>
-                <section class="hud-card info-panel" id="controlsCard" aria-labelledby="controlsCardTitle">
-                    <h2 class="card-title" id="controlsCardTitle">Flight Controls</h2>
-                    <div class="card-body">
-                        <div class="control-list" role="list">
-                            <div class="control-row" role="listitem">
-                                <div class="control-keys" aria-label="Movement keys">
-                                    <span class="keycap" aria-hidden="true">←</span>
-                                    <span class="keycap" aria-hidden="true">↑</span>
-                                    <span class="keycap" aria-hidden="true">↓</span>
-                                    <span class="keycap" aria-hidden="true">→</span>
-                                </div>
-                                <div class="control-action">Vector the catship through hazards.</div>
-                            </div>
-                            <div class="control-row" role="listitem">
-                                <div class="control-keys" aria-label="Fire control">
-                                    <span class="keycap wide" aria-hidden="true">Space</span>
-                                </div>
-                                <div class="control-action">Launch precision plasma bolts.</div>
-                            </div>
-                            <div class="control-row" role="listitem">
-                                <div class="control-keys" aria-label="Pause control">
-                                    <span class="keycap wide" aria-hidden="true">P</span>
-                                </div>
-                                <div class="control-action">Pause or resume the flight deck.</div>
-                            </div>
-                            <div class="control-row" role="listitem">
-                                <div class="control-keys" aria-label="Settings shortcut">
-                                    <span class="keycap wide" aria-hidden="true">Esc</span>
-                                </div>
-                                <div class="control-action">Open the quick settings panel mid-flight.</div>
-                            </div>
-                            <div class="control-row" role="listitem">
-                                <div class="control-keys" aria-label="Touch controls">
-                                    <span class="keycap wide" aria-hidden="true">Touch</span>
-                                </div>
-                                <div class="control-action">Drag the left pad to steer, tap Fire to engage, tap ⚙ to tweak settings.</div>
-                            </div>
-                            <div class="control-row" role="listitem">
-                                <div class="control-keys" aria-label="PS5 DualSense controls">
-                                    <span class="keycap wide" aria-hidden="true">DualSense</span>
-                                </div>
-                                <div class="control-action">
-                                    <p class="control-action-title">PS5 controller mapping</p>
-                                    <ul class="control-details" aria-label="DualSense button map">
-                                        <li><span class="control-label">Left Stick / D-Pad</span> Steer the catship. Double-tap a direction to trigger a dash burst through hazards.</li>
-                                        <li><span class="control-label">R2 / L2 / ✕ / □ / L1 / R1</span> Hold to keep the plasma cannons firing. Any of these triggers or face buttons will sustain fire.</li>
-                                        <li><span class="control-label">Options</span> Pause or resume mid-flight. From pre-flight or after a crash, Options also activates the highlighted launch, retry, or submit action.</li>
-                                        <li><span class="control-label">✕ (Cross)</span> Confirm prompts and advance menus, mirroring the main launch button.</li>
-                                    </ul>
-                                    <p class="control-tip">When pause or results overlays are open, focus snaps to the primary action. Use ✕ to confirm, or press Options again to return to the cockpit without selecting anything.</p>
-                                </div>
-                            </div>
-                        </div>
+                    <div class="stat-row">
+                        <span class="stat-label">Streak</span>
+                        <span class="value" id="streak">x1</span>
                     </div>
-                </section>
-                <section class="hud-card info-panel" id="missionCard" aria-labelledby="missionCardTitle">
-                    <h2 class="card-title" id="missionCardTitle">Mission Brief</h2>
-                    <div class="card-body">
-                        <ul class="mission-list">
-                            <li>Collect Points to fuel the escape and grow your score.</li>
-                            <li>Slip between asteroids and hostile fire to stay in the fight.</li>
-                            <li>Secure booster cores for temporary firepower and agility.</li>
-                            <li>Snag the Radiant Shield to ricochet villains and asteroids away.</li>
-                            <li>Channel Hyper Beam cores to carve safe corridors when the lane is crowded.</li>
-                            <li>Keep the combo meter charged to amplify every point.</li>
-                        </ul>
+                    <div class="stat-row">
+                        <span class="stat-label">Best Tail</span>
+                        <span class="value" id="bestStreak">0</span>
                     </div>
-                </section>
-                <section class="hud-card info-panel" id="intelCard" aria-labelledby="intelCardTitle">
-                    <h2 class="card-title" id="intelCardTitle">Tactical Intel</h2>
-                    <div class="card-body">
-                        <div class="challenge-section" aria-live="polite">
-                            <h3>Active Challenges</h3>
-                            <ul class="challenge-list" id="challengeList" role="list"></ul>
-                        </div>
-                        <div class="cosmetic-section" aria-live="polite">
-                            <h3>Cosmetic Loadout</h3>
-                            <div class="cosmetic-group" role="group" aria-label="Ship skins">
-                                <span class="cosmetic-group-label">Ship</span>
-                                <div class="cosmetic-options" id="skinOptions"></div>
-                            </div>
-                            <div class="cosmetic-group" role="group" aria-label="Trail styles">
-                                <span class="cosmetic-group-label">Trail</span>
-                                <div class="cosmetic-options" id="trailOptions"></div>
-                            </div>
-                            <div class="cosmetic-group" role="group" aria-label="Weapon systems">
-                                <span class="cosmetic-group-label">Weapon</span>
-                                <div class="cosmetic-options weapon-options" id="weaponOptions">
-                                    <div class="weapon-summary-card" aria-live="polite">
-                                        <img id="weaponSummaryImage" alt="" />
-                                        <div class="weapon-summary-copy">
-                                            <span id="weaponSummaryName" class="weapon-summary-name"></span>
-                                            <p id="weaponSummaryDescription" class="weapon-summary-description"></p>
-                                        </div>
-                                    </div>
-                                    <button
-                                        id="openWeaponSelectButton"
-                                        type="button"
-                                        class="cosmetic-option weapon-change-button"
-                                    >
-                                        Change Weapon
-                                    </button>
-                                </div>
-                            </div>
-                        </div>
-                        <ul class="intel-log" id="intelLog" role="list" aria-live="polite"></ul>
+                    <div class="stat-row">
+                        <span class="stat-label">MCAP</span>
+                        <span class="value" id="mcap">6.6K</span>
                     </div>
-                </section>
-                <section class="hud-card info-panel" id="socialCard" aria-labelledby="socialCardTitle">
-                    <h2 class="card-title" id="socialCardTitle">Squadron Feed</h2>
-                    <div class="card-body">
-                        <ul id="socialFeed" role="list"></ul>
+                    <div class="stat-row">
+                        <span class="stat-label">VOL</span>
+                        <span class="value" id="vol">2.8K</span>
                     </div>
-                </section>
-            </div>
-            <div
-                id="infoModal"
-                class="info-modal"
-                role="dialog"
-                aria-modal="true"
-                aria-labelledby="infoModalTitle"
-                hidden
-                tabindex="-1"
-            >
-                <div class="info-modal-content" role="document">
-                    <div class="info-modal-header">
-                        <h2 id="infoModalTitle"></h2>
-                        <button type="button" id="infoModalClose" class="info-modal-close" aria-label="Close panel">
-                            ✕
-                        </button>
+                    <div class="stat-row">
+                        <span class="stat-label">Boosts</span>
+                        <span class="value" id="powerUps">None</span>
                     </div>
-                    <div id="infoModalBody" class="info-modal-body"></div>
                 </div>
+                <div
+                    id="comboMeter"
+                    role="progressbar"
+                    aria-label="Combo charge"
+                    aria-valuemin="0"
+                    aria-valuemax="100"
+                    aria-valuenow="0"
+                >
+                    <div id="comboFill"></div>
+                </div>
+            </section>
+            <section class="hud-card info-panel" id="controlsCard" aria-labelledby="controlsCardTitle">
+                <h2 class="card-title" id="controlsCardTitle">Flight Controls</h2>
+                <div class="card-body">
+                    <div class="control-list" role="list">
+                        <div class="control-row" role="listitem">
+                            <div class="control-keys" aria-label="Movement keys">
+                                <span class="keycap" aria-hidden="true">←</span>
+                                <span class="keycap" aria-hidden="true">↑</span>
+                                <span class="keycap" aria-hidden="true">↓</span>
+                                <span class="keycap" aria-hidden="true">→</span>
+                            </div>
+                            <div class="control-action">Vector the catship through hazards.</div>
+                        </div>
+                        <div class="control-row" role="listitem">
+                            <div class="control-keys" aria-label="Fire control">
+                                <span class="keycap wide" aria-hidden="true">Space</span>
+                            </div>
+                            <div class="control-action">Launch precision plasma bolts.</div>
+                        </div>
+                        <div class="control-row" role="listitem">
+                            <div class="control-keys" aria-label="Pause control">
+                                <span class="keycap wide" aria-hidden="true">P</span>
+                            </div>
+                            <div class="control-action">Pause or resume the flight deck.</div>
+                        </div>
+                        <div class="control-row" role="listitem">
+                            <div class="control-keys" aria-label="Settings shortcut">
+                                <span class="keycap wide" aria-hidden="true">Esc</span>
+                            </div>
+                            <div class="control-action">Open the quick settings panel mid-flight.</div>
+                        </div>
+                        <div class="control-row" role="listitem">
+                            <div class="control-keys" aria-label="Touch controls">
+                                <span class="keycap wide" aria-hidden="true">Touch</span>
+                            </div>
+                            <div class="control-action">Drag the left pad to steer, tap Fire to engage, tap ⚙ to tweak settings.</div>
+                        </div>
+                        <div class="control-row" role="listitem">
+                            <div class="control-keys" aria-label="PS5 DualSense controls">
+                                <span class="keycap wide" aria-hidden="true">DualSense</span>
+                            </div>
+                            <div class="control-action">
+                                <p class="control-action-title">PS5 controller mapping</p>
+                                <ul class="control-details" aria-label="DualSense button map">
+                                    <li><span class="control-label">Left Stick / D-Pad</span> Steer the catship. Double-tap a direction to trigger a dash burst through hazards.</li>
+                                    <li><span class="control-label">R2 / L2 / ✕ / □ / L1 / R1</span> Hold to keep the plasma cannons firing. Any of these triggers or face buttons will sustain fire.</li>
+                                    <li><span class="control-label">Options</span> Pause or resume mid-flight. From pre-flight or after a crash, Options also activates the highlighted launch, retry, or submit action.</li>
+                                    <li><span class="control-label">✕ (Cross)</span> Confirm prompts and advance menus, mirroring the main launch button.</li>
+                                </ul>
+                                <p class="control-tip">When pause or results overlays are open, focus snaps to the primary action. Use ✕ to confirm, or press Options again to return to the cockpit without selecting anything.</p>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </section>
+            <section class="hud-card info-panel" id="missionCard" aria-labelledby="missionCardTitle">
+                <h2 class="card-title" id="missionCardTitle">Mission Brief</h2>
+                <div class="card-body">
+                    <ul class="mission-list">
+                        <li>Collect Points to fuel the escape and grow your score.</li>
+                        <li>Slip between asteroids and hostile fire to stay in the fight.</li>
+                        <li>Secure booster cores for temporary firepower and agility.</li>
+                        <li>Snag the Radiant Shield to ricochet villains and asteroids away.</li>
+                        <li>Channel Hyper Beam cores to carve safe corridors when the lane is crowded.</li>
+                        <li>Keep the combo meter charged to amplify every point.</li>
+                    </ul>
+                </div>
+            </section>
+            <section class="hud-card info-panel" id="intelCard" aria-labelledby="intelCardTitle">
+                <h2 class="card-title" id="intelCardTitle">Tactical Intel</h2>
+                <div class="card-body">
+                    <div class="challenge-section" aria-live="polite">
+                        <h3>Active Challenges</h3>
+                        <ul class="challenge-list" id="challengeList" role="list"></ul>
+                    </div>
+                    <div class="cosmetic-section" aria-live="polite">
+                        <h3>Cosmetic Loadout</h3>
+                        <div class="cosmetic-group" role="group" aria-label="Ship skins">
+                            <span class="cosmetic-group-label">Ship</span>
+                            <div class="cosmetic-options" id="skinOptions"></div>
+                        </div>
+                        <div class="cosmetic-group" role="group" aria-label="Trail styles">
+                            <span class="cosmetic-group-label">Trail</span>
+                            <div class="cosmetic-options" id="trailOptions"></div>
+                        </div>
+                        <div class="cosmetic-group" role="group" aria-label="Weapon systems">
+                            <span class="cosmetic-group-label">Weapon</span>
+                            <div class="cosmetic-options weapon-options" id="weaponOptions">
+                                <div class="weapon-summary-card" aria-live="polite">
+                                    <img id="weaponSummaryImage" alt="" />
+                                    <div class="weapon-summary-copy">
+                                        <span id="weaponSummaryName" class="weapon-summary-name"></span>
+                                        <p id="weaponSummaryDescription" class="weapon-summary-description"></p>
+                                    </div>
+                                </div>
+                                <button
+                                    id="openWeaponSelectButton"
+                                    type="button"
+                                    class="cosmetic-option weapon-change-button"
+                                >
+                                    Change Weapon
+                                </button>
+                            </div>
+                        </div>
+                    </div>
+                    <ul class="intel-log" id="intelLog" role="list" aria-live="polite"></ul>
+                </div>
+            </section>
+            <section class="hud-card info-panel" id="socialCard" aria-labelledby="socialCardTitle">
+                <h2 class="card-title" id="socialCardTitle">Squadron Feed</h2>
+                <div class="card-body">
+                    <ul id="socialFeed" role="list"></ul>
+                </div>
+            </section>
+        </div>
+        <div
+            id="infoModal"
+            class="info-modal"
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby="infoModalTitle"
+            hidden
+            tabindex="-1"
+        >
+            <div class="info-modal-content" role="document">
+                <div class="info-modal-header">
+                    <h2 id="infoModalTitle"></h2>
+                    <button type="button" id="infoModalClose" class="info-modal-close" aria-label="Close panel">
+                        ✕
+                    </button>
+                </div>
+                <div id="infoModalBody" class="info-modal-body"></div>
             </div>
         </div>
     </div>

--- a/styles/main.css
+++ b/styles/main.css
@@ -1,7 +1,7 @@
 :root {
     color-scheme: dark;
     --primary-font-stack: "Flight Time", "Segoe UI", Tahoma, Geneva, Verdana, sans-serif;
-    --shell-width: 1180px;
+    --shell-width: 720px;
     --shell-height: 720px;
     --shell-scale: 1;
     --shell-padding: clamp(24px, 5vw, 36px);
@@ -28,13 +28,14 @@ body {
     background: #000;
     display: flex;
     flex-direction: column;
-    justify-content: center;
+    justify-content: flex-start;
     align-items: center;
     min-height: 100vh;
     padding: var(--shell-padding);
     font-family: var(--primary-font-stack);
     color: #fff;
-    overflow: hidden;
+    overflow-x: hidden;
+    overflow-y: auto;
     position: relative;
 }
 
@@ -416,16 +417,11 @@ body.touch-enabled #settingsButton {
 }
 
 #gameShell {
-    --layout-gap: 24px;
     position: relative;
-    display: grid;
-    grid-template-columns:
-        minmax(0, 720px)
-        minmax(0, calc(var(--shell-width) - 720px - var(--layout-gap)));
-    grid-auto-rows: minmax(0, 1fr);
+    display: flex;
+    flex-direction: column;
     align-items: stretch;
-    justify-content: center;
-    gap: var(--layout-gap);
+    justify-content: flex-start;
     width: min(var(--shell-width), calc(100vw - var(--shell-padding) * 2));
     max-width: var(--shell-width);
     height: min(var(--shell-height), calc(100vh - var(--shell-padding) * 2));
@@ -772,21 +768,6 @@ body.touch-enabled #preflightPrompt .desktop-only {
     #preflightPrompt::after {
         inset: clamp(6px, 3vw, 10px);
     }
-}
-
-#settingsHint {
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    padding: 8px 12px;
-    border-radius: 8px;
-    border: 2px solid rgba(255, 255, 255, 0.18);
-    background: rgba(15, 23, 42, 0.5);
-    font-size: clamp(10px, 2vw, 12px);
-    letter-spacing: 0.16em;
-    text-transform: uppercase;
-    color: rgba(226, 232, 240, 0.92);
-    text-align: center;
 }
 
 #stats span.value {
@@ -2547,25 +2528,25 @@ body.weapon-select-open {
     background: linear-gradient(90deg, rgba(16, 185, 129, 0.9), rgba(59, 130, 246, 0.9));
 }
 #instructions {
-    width: 100%;
-    margin: 0;
+    width: min(var(--shell-width), calc(100vw - var(--shell-padding) * 2));
+    max-width: var(--shell-width);
+    margin: clamp(16px, 4vw, 24px) auto 0;
     display: flex;
     flex-direction: column;
     align-items: stretch;
-    justify-content: stretch;
     gap: 16px;
-    height: 100%;
 }
 
 #instructionButtonBar {
     display: flex;
     align-items: stretch;
-    justify-content: space-between;
+    justify-content: center;
     gap: 12px;
+    row-gap: 10px;
     width: 100%;
     margin: 0;
     padding: 0;
-    flex-wrap: nowrap;
+    flex-wrap: wrap;
 }
 
 #instructionPanels {
@@ -2576,6 +2557,7 @@ body.weapon-select-open {
     flex-direction: column;
     gap: 16px;
     padding-right: 8px;
+    max-height: clamp(320px, 50vh, 520px);
 }
 
 #instructionPanels[hidden] {


### PR DESCRIPTION
## Summary
- move the instruction toolbar and panels beneath the playfield so the mission buttons sit below the gameplay area
- drop the "Press Esc" settings hint from the preflight bar
- retune the layout CSS to support the new vertical flow, including updated shell width, scrolling behaviour, and responsive sizing for the instruction panels

## Testing
- not run (frontend changes only)

------
https://chatgpt.com/codex/tasks/task_e_68d04ff02800832492539a1dfae78e1d