### PR TITLE
Ensure consistent game resolution and reposition instruction buttons

### DIFF
--- a/styles/main.css
+++ b/styles/main.css
@@ -31,8 +31,8 @@ body {
     justify-content: flex-start;
     align-items: center;
     min-height: 100vh;
-    padding: var(--shell-padding);
-    padding-inline: 10px;
+    padding: 0 10px 10px;
+    padding-top: var(--shell-padding);
     font-family: var(--primary-font-stack);
     color: #fff;
     overflow-x: hidden;
@@ -423,11 +423,9 @@ body.touch-enabled #settingsButton {
     flex-direction: column;
     align-items: stretch;
     justify-content: flex-start;
-    width: calc(100% - 20px);
-    max-width: none;
-    height: min(var(--shell-height), calc(100vh - var(--shell-padding) * 2));
-    max-height: var(--shell-height);
-    margin: 0 10px;
+    width: var(--shell-width);
+    height: var(--shell-height);
+    margin: 0 auto;
     z-index: 0;
     transform-origin: top center;
     transform: scale(var(--shell-scale));
@@ -2534,13 +2532,14 @@ body.weapon-select-open {
     background: linear-gradient(90deg, rgba(16, 185, 129, 0.9), rgba(59, 130, 246, 0.9));
 }
 #instructions {
-    width: calc(100% - 20px);
-    max-width: none;
+    width: min(var(--shell-width), calc(100% - 20px));
     margin: 5px 10px 0;
+    margin-top: auto;
     display: flex;
     flex-direction: column;
     align-items: stretch;
     gap: 16px;
+    padding-top: clamp(18px, 4vh, 36px);
 }
 
 #instructionButtonBar {


### PR DESCRIPTION
## Summary
- fix the game shell to use the design-width/height variables so the canvas renders at a consistent resolution across browsers before being scaled
- adjust the body padding and instruction container spacing so the instruction buttons sit 10px above the bottom of the viewport with consistent breathing room

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d054898e948324a1b3fe5d61526715