### PR TITLE
Add customizable loadout presets with visual builder

### DIFF
--- a/index.html
+++ b/index.html
@@ -230,6 +230,14 @@
                                 </button>
                             </div>
                         </div>
+                        <div class="custom-loadout-section" id="customLoadoutSection" aria-live="polite">
+                            <h4>Custom Loadouts</h4>
+                            <p class="custom-loadout-description">
+                                Capture two personalized presets. Pick your pilot, suit, stream, and weapon, then save the
+                                configuration for fast launches.
+                            </p>
+                            <div class="custom-loadout-grid" data-loadout-grid role="list"></div>
+                        </div>
                     </div>
                     <ul class="intel-log" id="intelLog" role="list" aria-live="polite"></ul>
                 </div>

--- a/styles/main.css
+++ b/styles/main.css
@@ -1163,6 +1163,296 @@ body.touch-enabled #preflightPrompt .desktop-only {
     padding-inline: 18px;
 }
 
+.custom-loadout-section {
+    display: flex;
+    flex-direction: column;
+    gap: 14px;
+    margin-top: 12px;
+    padding-top: 14px;
+    border-top: 1px solid rgba(148, 210, 255, 0.18);
+}
+
+.custom-loadout-section h4 {
+    margin: 0;
+    font-size: 0.82rem;
+    letter-spacing: 0.18em;
+    text-transform: uppercase;
+    color: rgba(148, 210, 255, 0.85);
+}
+
+.custom-loadout-description {
+    margin: 0;
+    font-size: 0.74rem;
+    line-height: 1.55;
+    color: rgba(226, 232, 240, 0.82);
+}
+
+.custom-loadout-grid {
+    display: grid;
+    gap: 16px;
+}
+
+@media (min-width: 640px) {
+    .custom-loadout-grid {
+        grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+    }
+}
+
+.custom-loadout-card {
+    position: relative;
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+    padding: 18px;
+    border-radius: 20px;
+    background: linear-gradient(140deg, rgba(15, 23, 42, 0.85), rgba(14, 116, 144, 0.32));
+    border: 1px solid rgba(148, 210, 255, 0.26);
+    box-shadow: 0 18px 34px rgba(5, 8, 25, 0.45);
+    transition: border-color 180ms ease, box-shadow 180ms ease;
+}
+
+.custom-loadout-card.is-active {
+    border-color: rgba(244, 114, 182, 0.85);
+    box-shadow: 0 22px 44px rgba(244, 114, 182, 0.32);
+}
+
+.custom-loadout-card.has-locked {
+    border-color: rgba(248, 113, 113, 0.6);
+}
+
+.custom-loadout-badge {
+    position: absolute;
+    top: 12px;
+    right: 12px;
+    background: linear-gradient(135deg, rgba(244, 114, 182, 0.95), rgba(56, 189, 248, 0.95));
+    color: #fff;
+    font-size: 0.58rem;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+    padding: 4px 10px;
+    border-radius: 999px;
+    box-shadow: 0 10px 18px rgba(37, 99, 235, 0.35);
+}
+
+.custom-loadout-header {
+    display: flex;
+    gap: 12px;
+    align-items: flex-end;
+    justify-content: space-between;
+}
+
+.custom-loadout-name-field {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    flex: 1;
+}
+
+.custom-loadout-name-label {
+    font-size: 0.64rem;
+    letter-spacing: 0.14em;
+    text-transform: uppercase;
+    color: rgba(148, 210, 255, 0.68);
+}
+
+.custom-loadout-name-input {
+    width: 100%;
+    border-radius: 14px;
+    border: 1px solid rgba(148, 210, 255, 0.34);
+    background: rgba(15, 23, 42, 0.72);
+    color: #e2e8f0;
+    padding: 9px 12px;
+    font-size: 0.78rem;
+    transition: border-color 160ms ease, box-shadow 160ms ease;
+}
+
+.custom-loadout-name-input:focus {
+    border-color: rgba(56, 189, 248, 0.82);
+    box-shadow: 0 0 0 3px rgba(56, 189, 248, 0.25);
+    outline: none;
+}
+
+.custom-loadout-save {
+    border-radius: 999px;
+    border: 1px solid rgba(148, 210, 255, 0.32);
+    background: rgba(15, 23, 42, 0.65);
+    color: rgba(226, 232, 240, 0.92);
+    font-size: 0.64rem;
+    letter-spacing: 0.14em;
+    text-transform: uppercase;
+    padding: 8px 16px;
+    cursor: pointer;
+    transition: transform 160ms ease, box-shadow 160ms ease, border-color 160ms ease;
+}
+
+.custom-loadout-save:hover,
+.custom-loadout-save:focus-visible {
+    transform: translateY(-1px);
+    border-color: rgba(148, 210, 255, 0.75);
+    box-shadow: 0 14px 26px rgba(14, 116, 144, 0.35);
+    outline: none;
+}
+
+.custom-loadout-body {
+    display: flex;
+    flex-direction: column;
+    gap: 14px;
+}
+
+.custom-loadout-preview-row {
+    display: flex;
+    gap: 12px;
+    align-items: center;
+}
+
+.custom-loadout-preview-thumb {
+    width: 64px;
+    height: 64px;
+    border-radius: 16px;
+    background: rgba(15, 23, 42, 0.72);
+    border: 1px solid rgba(56, 189, 248, 0.28);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    overflow: hidden;
+    box-shadow: inset 0 0 0 1px rgba(15, 23, 42, 0.2);
+}
+
+.custom-loadout-preview-thumb img {
+    width: 100%;
+    height: 100%;
+    object-fit: contain;
+    filter: drop-shadow(0 12px 20px rgba(56, 189, 248, 0.3));
+}
+
+.custom-loadout-preview-info {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+}
+
+.custom-loadout-preview-title {
+    font-size: 0.64rem;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+    color: rgba(148, 210, 255, 0.7);
+}
+
+.custom-loadout-preview-value {
+    font-size: 0.82rem;
+    color: rgba(226, 232, 240, 0.94);
+}
+
+.custom-loadout-link {
+    border: none;
+    background: none;
+    color: rgba(148, 210, 255, 0.86);
+    font-size: 0.64rem;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+    cursor: pointer;
+    padding: 0;
+    align-self: flex-start;
+    transition: color 160ms ease;
+}
+
+.custom-loadout-link:hover,
+.custom-loadout-link:focus-visible {
+    color: rgba(244, 114, 182, 0.92);
+    text-decoration: underline;
+    outline: none;
+}
+
+.custom-loadout-tags {
+    display: grid;
+    gap: 12px;
+}
+
+@media (min-width: 540px) {
+    .custom-loadout-tags {
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
+}
+
+.custom-loadout-tag {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    padding: 12px;
+    border-radius: 16px;
+    background: rgba(15, 23, 42, 0.66);
+    border: 1px solid rgba(56, 189, 248, 0.28);
+}
+
+.custom-loadout-tag-label {
+    font-size: 0.62rem;
+    letter-spacing: 0.14em;
+    text-transform: uppercase;
+    color: rgba(148, 210, 255, 0.7);
+}
+
+.custom-loadout-tag-value {
+    font-size: 0.78rem;
+    color: rgba(226, 232, 240, 0.9);
+}
+
+.custom-loadout-trail-swatch {
+    width: 100%;
+    height: 6px;
+    border-radius: 999px;
+    box-shadow: 0 6px 14px rgba(56, 189, 248, 0.32);
+}
+
+.custom-loadout-footer {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+}
+
+.custom-loadout-apply {
+    align-self: flex-start;
+    border: none;
+    border-radius: 999px;
+    padding: 10px 20px;
+    font-size: 0.68rem;
+    letter-spacing: 0.14em;
+    text-transform: uppercase;
+    font-weight: 600;
+    background: linear-gradient(135deg, rgba(56, 189, 248, 0.92), rgba(99, 102, 241, 0.92));
+    color: #fff;
+    cursor: pointer;
+    box-shadow: 0 14px 28px rgba(37, 99, 235, 0.4);
+    transition: transform 160ms ease, box-shadow 160ms ease;
+}
+
+.custom-loadout-apply:hover,
+.custom-loadout-apply:focus-visible {
+    transform: translateY(-1px);
+    box-shadow: 0 18px 32px rgba(56, 189, 248, 0.45);
+    outline: none;
+}
+
+.custom-loadout-status {
+    margin: 0;
+    min-height: 0.9rem;
+    font-size: 0.7rem;
+    color: rgba(148, 210, 255, 0.82);
+}
+
+.custom-loadout-status.error {
+    color: rgba(248, 113, 113, 0.92);
+}
+
+.custom-loadout-status.success {
+    color: rgba(52, 211, 153, 0.88);
+}
+
+.custom-loadout-locked {
+    margin: 0;
+    font-size: 0.68rem;
+    color: rgba(248, 113, 113, 0.9);
+}
+
 .cosmetic-option {
     border: 1px solid rgba(148, 210, 255, 0.18);
     background: rgba(15, 23, 42, 0.45);


### PR DESCRIPTION
## Summary
- allow players to save two named custom loadout presets persisted in local storage
- add a visual loadout builder card with pilot & weapon imagery plus quick actions to adjust suit, stream, and equipment
- wire presets to apply active character/cosmetics with ownership validation and contextual status messaging

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d0583f94f4832493e5617528ff005c