### PR TITLE
Expand gameplay layout width and button spacing

### DIFF
--- a/styles/main.css
+++ b/styles/main.css
@@ -1,7 +1,7 @@
 :root {
     color-scheme: dark;
     --primary-font-stack: "Flight Time", "Segoe UI", Tahoma, Geneva, Verdana, sans-serif;
-    --shell-width: 720px;
+    --shell-width: auto;
     --shell-height: 720px;
     --shell-scale: 1;
     --shell-padding: clamp(24px, 5vw, 36px);
@@ -423,9 +423,9 @@ body.touch-enabled #settingsButton {
     flex-direction: column;
     align-items: stretch;
     justify-content: flex-start;
-    width: min(var(--shell-width), calc(100% - 20px));
+    width: calc(100% - 20px);
     height: var(--shell-height);
-    margin: 0 auto;
+    margin: 0 10px;
     margin-bottom: max(0px, calc((var(--shell-scale) - 1) * var(--shell-height)));
     z-index: 0;
     transform-origin: top center;
@@ -438,7 +438,7 @@ body.touch-enabled #settingsButton {
     grid-template-rows: minmax(0, 1fr) auto;
     align-items: stretch;
     justify-items: center;
-    gap: clamp(18px, 3vw, 28px);
+    gap: 10px;
     width: 100%;
     height: 100%;
     margin: 0;


### PR DESCRIPTION
## Summary
- allow the gameplay shell to stretch across the page with 10px gutters so the mascot can overlap the interface
- reduce the spacing between the playfield and its button row to 10px for a tighter layout
- set the shell width variable to auto so scaling follows the resized layout

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d05cd452a08324b84e5d8d6ce52bb5