### PR TITLE
Make gameplay shell responsive and streamline loadouts

### DIFF
--- a/index.html
+++ b/index.html
@@ -321,8 +321,8 @@
             </div>
             <div id="pilotPreview" aria-live="polite">
                 <div class="pilot-preview-header">
-                    <h2>Pilot Loadouts</h2>
-                    <p id="pilotPreviewDescription">Each pilot tweaks the ship's handling. Compare at a glance, then open the hangar to inspect full specs.</p>
+                    <h2>Custom Loadouts</h2>
+                    <p id="pilotPreviewDescription">Equip one of your saved presets instantly before launch. Manage the presets in the Custom Loadouts panel below.</p>
                 </div>
                 <div id="pilotPreviewGrid" class="pilot-preview-grid" role="list"></div>
             </div>

--- a/styles/main.css
+++ b/styles/main.css
@@ -29,7 +29,7 @@ body {
     display: flex;
     flex-direction: column;
     justify-content: flex-start;
-    align-items: center;
+    align-items: stretch;
     min-height: 100vh;
     padding: 0 10px 10px;
     padding-top: var(--shell-padding);
@@ -423,21 +423,19 @@ body.touch-enabled #settingsButton {
     flex-direction: column;
     align-items: stretch;
     justify-content: flex-start;
-    width: calc(100% - 20px);
-    height: var(--shell-height);
-    margin: 0 10px;
-    margin-bottom: max(0px, calc((var(--shell-scale) - 1) * var(--shell-height)));
+    width: 100%;
+    max-width: 100%;
+    height: auto;
+    margin: 0;
     z-index: 0;
-    transform-origin: top center;
-    transform: scale(var(--shell-scale));
 }
 
 #playfield {
     position: relative;
     display: grid;
-    grid-template-rows: minmax(0, 1fr) auto;
+    grid-template-rows: auto auto;
     align-items: stretch;
-    justify-items: center;
+    justify-items: stretch;
     gap: 10px;
     width: 100%;
     height: 100%;
@@ -447,6 +445,10 @@ body.touch-enabled #settingsButton {
 #gameCanvas {
     max-width: 100%;
     max-height: 100%;
+}
+
+#preflightBar[hidden] {
+    display: none;
 }
 
 #loadingScreen {
@@ -2735,11 +2737,12 @@ body.weapon-select-open {
     padding: 12px;
     display: flex;
     flex-direction: column;
-    gap: 10px;
+    gap: 12px;
     color: rgba(226, 232, 240, 0.92);
     font: inherit;
     letter-spacing: 0.01em;
     cursor: pointer;
+    text-align: left;
     transition: transform 140ms ease, border-color 140ms ease, box-shadow 140ms ease;
 }
 
@@ -2759,10 +2762,6 @@ body.weapon-select-open {
     box-shadow: 0 16px 36px rgba(59, 130, 246, 0.38);
 }
 
-.pilot-preview-card.pending:not(.active) {
-    border-color: rgba(251, 191, 36, 0.55);
-}
-
 .pilot-preview-header-row {
     display: flex;
     justify-content: space-between;
@@ -2777,50 +2776,53 @@ body.weapon-select-open {
 }
 
 .pilot-preview-role {
-    font-size: 0.62rem;
-    letter-spacing: 0.08em;
-    text-transform: uppercase;
-    color: rgba(148, 163, 184, 0.8);
-}
-
-.pilot-preview-stats {
-    display: flex;
-    flex-direction: column;
-    gap: 8px;
-}
-
-.pilot-preview-stat {
-    display: flex;
-    align-items: center;
-    gap: 8px;
-}
-
-.pilot-preview-stat-label {
-    font-size: 0.58rem;
-    letter-spacing: 0.06em;
+    font-size: 0.6rem;
+    letter-spacing: 0.12em;
     text-transform: uppercase;
     color: rgba(148, 163, 184, 0.75);
-    min-width: 72px;
 }
 
-.pilot-preview-bar {
-    flex: 1;
-    height: 6px;
-    border-radius: 999px;
-    background: rgba(30, 41, 59, 0.65);
-    overflow: hidden;
+.pilot-preview-card.active .pilot-preview-role {
+    color: rgba(129, 230, 217, 0.92);
 }
 
-.pilot-preview-bar-fill {
-    height: 100%;
-    border-radius: inherit;
-    background: linear-gradient(90deg, rgba(56, 189, 248, 0.85), rgba(129, 140, 248, 0.85));
-    width: 0%;
-    transition: width 180ms ease;
+.pilot-preview-card.has-locked .pilot-preview-role {
+    color: rgba(248, 113, 113, 0.9);
 }
 
-.pilot-preview-card.active .pilot-preview-bar-fill {
-    background: linear-gradient(90deg, rgba(16, 185, 129, 0.9), rgba(59, 130, 246, 0.9));
+.pilot-preview-meta {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    margin: 0;
+    padding: 0;
+}
+
+.pilot-preview-meta-row {
+    display: flex;
+    justify-content: space-between;
+    align-items: baseline;
+    gap: 12px;
+}
+
+.pilot-preview-meta-label {
+    font-size: 0.6rem;
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+    color: rgba(148, 163, 184, 0.75);
+}
+
+.pilot-preview-meta-value {
+    font-size: 0.7rem;
+    font-weight: 600;
+    color: rgba(226, 232, 240, 0.95);
+    text-align: right;
+}
+
+.pilot-preview-locked {
+    margin: 0;
+    font-size: 0.6rem;
+    color: rgba(248, 113, 113, 0.88);
 }
 #instructions {
     width: calc(100% - 20px);


### PR DESCRIPTION
## Summary
- expand the gameplay shell to fill the available viewport width and collapse pre-flight padding when prompts are hidden
- replace the pre-flight pilot cards with the two saved custom loadouts, including lock messaging and quick equip actions
- sync custom loadout edits with the quick launch preview so saved names and ownership states stay up to date

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68d05edcb0708324878aae8b55405e54