### PR TITLE
Fix loadout initialization order to avoid weaponLoadouts error

### DIFF
--- a/scripts/app.js
+++ b/scripts/app.js
@@ -6922,12 +6922,6 @@ document.addEventListener('DOMContentLoaded', () => {
     let activeWeaponId = 'pulse';
     let pendingWeaponId = 'pulse';
     let weaponSelectReturnFocus = null;
-    renderCharacterSelectCards();
-    renderPilotPreview();
-    refreshPilotPreviewStates();
-    updateSwapPilotButton();
-    updateWeaponInlineSummary();
-    updateSwapWeaponButtons();
     const trailStyles = {
         rainbow: { id: 'rainbow', label: 'Prismatic Stream', type: 'spectrum' },
         aurora: {
@@ -7213,6 +7207,13 @@ document.addEventListener('DOMContentLoaded', () => {
     weaponProfileMap = new Map(weaponProfiles.map((profile) => [profile.id, profile]));
     renderWeaponSelectCards();
     refreshWeaponSelectionDisplay();
+
+    renderCharacterSelectCards();
+    renderPilotPreview();
+    refreshPilotPreviewStates();
+    updateSwapPilotButton();
+    updateWeaponInlineSummary();
+    updateSwapWeaponButtons();
 
     function getCurrentCosmeticsSelection() {
         const fallbackWeapon = typeof activeWeaponId === 'string' && activeWeaponId ? activeWeaponId : 'pulse';


### PR DESCRIPTION
## Summary
- defer initial render/setup calls until after trail, weapon loadout, and profile data are defined to avoid temporal dead zone errors while normalizing custom loadouts

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d064ec004483248c3c33b588efb680