### PR TITLE
Adjust layout to keep game and controls within viewport

### DIFF
--- a/styles/main.css
+++ b/styles/main.css
@@ -33,18 +33,22 @@ canvas {
 body {
     margin: 0;
     background: #000;
-    display: grid;
-    grid-template-rows: minmax(0, 1fr) auto;
+    display: flex;
+    flex-direction: column;
     align-items: stretch;
-    justify-items: stretch;
+    justify-content: flex-start;
     min-height: 100vh;
+    min-height: 100svh;
+    min-height: 100dvh;
     height: 100vh;
+    height: 100svh;
+    height: 100dvh;
     padding: var(--shell-padding);
     font-family: var(--primary-font-stack);
     color: #fff;
     overflow: hidden;
     position: relative;
-    row-gap: 10px;
+    gap: var(--shell-padding);
     -webkit-tap-highlight-color: transparent;
 }
 
@@ -431,10 +435,11 @@ body.touch-enabled #settingsButton {
     flex-direction: column;
     align-items: stretch;
     justify-content: flex-start;
-    width: 100%;
+    width: min(100%, 1280px);
     max-width: 100%;
-    height: 100%;
-    margin: 0;
+    flex: 1 1 auto;
+    height: auto;
+    margin: 0 auto;
     z-index: 0;
     min-height: 0;
 }
@@ -2837,16 +2842,18 @@ body.weapon-select-open {
     color: rgba(248, 113, 113, 0.88);
 }
 #instructions {
-    width: 100%;
+    width: min(100%, 1280px);
     max-width: 100%;
-    margin: 0;
+    margin: 0 auto;
     display: grid;
     grid-template-rows: auto 1fr;
     align-items: stretch;
     justify-items: stretch;
     gap: 12px;
     padding-top: 0;
-    height: clamp(200px, 35vh, 320px);
+    flex: 0 0 clamp(160px, 28vh, 260px);
+    height: clamp(160px, 28vh, 260px);
+    max-height: clamp(160px, 28vh, 260px);
     min-height: 0;
     overflow: hidden;
 }


### PR DESCRIPTION
## Summary
- switch the top-level layout to a flex column so the playfield stays anchored at the top and controls stay pinned to the bottom
- cap the maximum width for the playfield and instruction tray and give the control tray a fixed flex height so everything fits without scrolling

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68d06bd1b2c48324a981cb93d06318cb