### PR TITLE
Align game canvas to 16x9 layout

### DIFF
--- a/scripts/app.js
+++ b/scripts/app.js
@@ -1565,16 +1565,16 @@ document.addEventListener('DOMContentLoaded', () => {
     let isTouchInterface = coarsePointerQuery?.matches ?? ('ontouchstart' in window);
     const TOUCH_SMOOTHING_RATE = 26;
     const DEBUG_OVERLAY_STORAGE_KEY = 'nyanEscape.debugOverlay';
-    const TARGET_ASPECT_RATIO = 3 / 2;
+    const TARGET_ASPECT_RATIO = 16 / 9;
     const gameShell = document.getElementById('gameShell');
     const rootElement = document.documentElement;
     const viewport = {
-        width: 900,
-        height: 600,
-        cssWidth: 900,
-        cssHeight: 600,
-        physicalWidth: 900,
-        physicalHeight: 600,
+        width: 1280,
+        height: 720,
+        cssWidth: 1280,
+        cssHeight: 720,
+        physicalWidth: 1280,
+        physicalHeight: 720,
         dpr: window.devicePixelRatio || 1
     };
 

--- a/styles/main.css
+++ b/styles/main.css
@@ -1,7 +1,7 @@
 :root {
     color-scheme: dark;
     --primary-font-stack: "Flight Time", "Segoe UI", Tahoma, Geneva, Verdana, sans-serif;
-    --shell-width: auto;
+    --shell-width: 1280px;
     --shell-height: 720px;
     --shell-scale: 1;
     --shell-padding: 10px;
@@ -458,6 +458,7 @@ body.touch-enabled #settingsButton {
 }
 
 #gameCanvas {
+    aspect-ratio: 16 / 9;
     max-width: 100%;
     max-height: 100%;
     width: 100%;


### PR DESCRIPTION
## Summary
- set the design shell dimensions to 1280×720 so scaling math uses the intended layout
- force the runtime canvas calculations to target a 16:9 aspect ratio and update the default viewport metrics
- expose the aspect ratio in CSS so the canvas keeps the correct shape before JavaScript runs

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d06e00edc48324b1825baee9fd8caf