### PR TITLE
Fix canvas layout scaling bug on small screens

### DIFF
--- a/scripts/app.js
+++ b/scripts/app.js
@@ -1761,14 +1761,13 @@ document.addEventListener('DOMContentLoaded', () => {
     function measureAvailableCanvasSize() {
         const parent = canvas?.parentElement ?? null;
         const parentRect = parent?.getBoundingClientRect();
-        const scale = shellScale || 1;
         const measuredWidth = Number.isFinite(parentRect?.width) ? parentRect.width : viewport.width;
         const measuredHeight = Number.isFinite(parentRect?.height) ? parentRect.height : viewport.height;
-        const availableWidth = Math.max(240, Math.floor(measuredWidth / scale));
-        let availableHeight = Math.floor(measuredHeight / scale);
+        const availableWidth = Math.max(240, Math.floor(measuredWidth));
+        let availableHeight = Math.floor(measuredHeight);
         if (!Number.isFinite(availableHeight) || availableHeight <= 0) {
             const fallbackHeight = (window.innerHeight || viewport.height) - 48;
-            availableHeight = Math.max(240, Math.floor(fallbackHeight / scale));
+            availableHeight = Math.max(240, Math.floor(fallbackHeight));
         }
         return { width: availableWidth, height: Math.max(240, availableHeight) };
     }


### PR DESCRIPTION
## Summary
- remove an incorrect shell scaling adjustment when measuring the canvas size
- ensure the canvas uses the actual parent dimensions so gameplay renders at the correct size on smaller viewports

## Testing
- ⚠️ Not run (no automated tests available)


------
https://chatgpt.com/codex/tasks/task_e_68d0724e1e4083248e2969a9ddb36a23