### PR TITLE
Adjust loading screen styling

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,6 +14,7 @@
 <body>
     <div id="loadingScreen">
         <img src="assets/logo.png" alt="Cyborg boot sequence" id="loadingImage">
+        <p class="loading-credit">by @dasfruits</p>
         <div id="loadingStatus">
             <span class="loading-prefix">[SYS-BOOT:00]</span>
             <span class="loading-line">Initializing quantum cores — <span class="loading-percent">000%</span></span>

--- a/styles/main.css
+++ b/styles/main.css
@@ -476,11 +476,9 @@ body.touch-enabled #settingsButton {
     flex-direction: column;
     justify-content: center;
     align-items: center;
-    gap: clamp(24px, 4vw, 48px);
+    gap: 5px;
     padding: clamp(28px, 6vw, 80px);
-    background:
-        linear-gradient(rgba(15, 23, 42, 0.88), rgba(15, 23, 42, 0.9)),
-        url('../assets/background.png') center / cover no-repeat;
+    background: #fff;
     z-index: 999;
     transition: opacity 400ms ease;
     text-align: center;
@@ -498,6 +496,13 @@ body.touch-enabled #settingsButton {
     display: block;
     margin: 0 auto;
     align-self: center;
+}
+
+.loading-credit {
+    font-family: "Inter", "Helvetica Neue", Arial, sans-serif;
+    font-size: 1rem;
+    color: #0f172a;
+    margin: 0;
 }
 
 #loadingStatus {


### PR DESCRIPTION
## Summary
- set the loading screen background to a clean white backdrop
- insert a credit line beneath the logo and tighten vertical spacing

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d07d7b32a883248097fd95afba67e1