### PR TITLE
Fix loadout editor modal stacking

### DIFF
--- a/styles/main.css
+++ b/styles/main.css
@@ -2015,7 +2015,7 @@ body.loadout-editor-open {
 #loadoutEditorModal {
     position: fixed;
     inset: 0;
-    z-index: 8;
+    z-index: 120;
     display: flex;
     justify-content: center;
     align-items: center;


### PR DESCRIPTION
## Summary
- raise the character, weapon, and loadout editor modal stacking context so the dialog renders above other overlays

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d079dfe0f48324b64b2557a87b9631