### PR TITLE
Adjust instructions layout to shrink footer gap

### DIFF
--- a/styles/main.css
+++ b/styles/main.css
@@ -2992,16 +2992,28 @@ body.loadout-editor-open {
     max-width: none;
     margin: 0;
     display: grid;
-    grid-template-rows: auto 1fr;
+    grid-template-rows: auto;
     align-items: stretch;
     justify-items: stretch;
     gap: 12px;
     padding-top: 0;
+    flex: 0 0 auto;
+    height: auto;
+    max-height: none;
+    min-height: 0;
+    overflow: visible;
+}
+
+#instructions[data-active-panel] {
+    grid-template-rows: auto 1fr;
     flex: 0 0 clamp(160px, 28vh, 260px);
     height: clamp(160px, 28vh, 260px);
     max-height: clamp(160px, 28vh, 260px);
-    min-height: 0;
     overflow: hidden;
+}
+
+#instructions:not([data-active-panel]) #instructionPanels {
+    display: none;
 }
 
 #instructionButtonBar {


### PR DESCRIPTION
## Summary
- allow the instructions footer to collapse to its button height so the game canvas can grow taller
- restore the previous fixed-height behaviour when an instruction panel is opened and hide the empty panel container when collapsed

## Testing
- no automated tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68d07aa8d30483249070ce6d59672009