### PR TITLE
Center playfield stage for symmetrical layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -37,13 +37,15 @@
     <div id="controllerCursor" aria-hidden="true"></div>
     <div id="gameShell">
         <div id="playfield">
-            <canvas id="gameCanvas" tabindex="0" aria-label="Nyan Escape flight deck"></canvas>
-            <div id="debugOverlay" aria-hidden="true" hidden>
-                <div data-debug-line="logical"></div>
-                <div data-debug-line="physical"></div>
-                <div data-debug-line="ratio"></div>
+            <div id="playfieldStage">
+                <canvas id="gameCanvas" tabindex="0" aria-label="Nyan Escape flight deck"></canvas>
+                <div id="debugOverlay" aria-hidden="true" hidden>
+                    <div data-debug-line="logical"></div>
+                    <div data-debug-line="physical"></div>
+                    <div data-debug-line="ratio"></div>
+                </div>
+                <div id="survivalTimer">Flight Time: <span class="value" id="timerValue">00:00.0</span></div>
             </div>
-            <div id="survivalTimer">Flight Time: <span class="value" id="timerValue">00:00.0</span></div>
             <div id="preflightBar">
                 <div id="preflightPrompt" role="status" aria-live="polite" hidden>
                     <span class="hud-title" aria-hidden="true">Nyan Ready</span>

--- a/styles/main.css
+++ b/styles/main.css
@@ -457,6 +457,15 @@ body.touch-enabled #settingsButton {
     margin: 0;
 }
 
+#playfieldStage {
+    position: relative;
+    width: min(100%, calc(var(--shell-width) * var(--shell-scale)));
+    max-width: 100%;
+    margin: 0 auto;
+    min-height: 0;
+    justify-self: center;
+}
+
 #gameCanvas {
     aspect-ratio: 16 / 9;
     max-width: 100%;


### PR DESCRIPTION
## Summary
- wrap the main game canvas and overlays in a new playfield stage container
- constrain and center the playfield stage based on the shell scale so the canvas stays symmetric within the viewport

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d083cfc38c8324bf420a3b4a1b71fa