### PR TITLE
Center gameplay canvas within playfield

### DIFF
--- a/styles/main.css
+++ b/styles/main.css
@@ -580,6 +580,8 @@ canvas {
     background: linear-gradient(180deg, rgba(5, 18, 55, 0.95) 0%, rgba(8, 27, 70, 0.95) 45%, rgba(0, 4, 20, 0.98) 100%);
     border-radius: 10px;
     box-shadow: 0 20px 45px rgba(0, 0, 0, 0.55);
+    display: block;
+    margin-inline: auto;
 }
 
 #debugOverlay {


### PR DESCRIPTION
## Summary
- center the gameplay canvas within its playfield wrapper so the horizontal spacing matches on both sides

## Testing
- Manual QA in browser

------
https://chatgpt.com/codex/tasks/task_e_68d089e2f3f4832482fd3055ce230ad1