### PR TITLE
Fix collectible condition precedence

### DIFF
--- a/scripts/app.js
+++ b/scripts/app.js
@@ -5504,7 +5504,7 @@ document.addEventListener('DOMContentLoaded', () => {
                 case 'score':
                     return state.stats.score >= Number(threshold ?? 0);
                 case 'collectible':
-                    return state.stats.collectibles >= Number(threshold ?? 0 || 0);
+                    return state.stats.collectibles >= Number((threshold ?? 0) || 0);
                 case 'powerUp':
                     if (eventType !== 'powerUp') {
                         return false;


### PR DESCRIPTION
## Summary
- wrap the nullish coalescing check for collectibles with parentheses to avoid syntax errors in browsers without mixing operators support

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d0b6f922f88324a4246343e219d9b0