### PR TITLE
Fix font loading regression

### DIFF
--- a/scripts/app.js
+++ b/scripts/app.js
@@ -63,6 +63,72 @@ document.addEventListener('DOMContentLoaded', () => {
             : null;
     const systemPrefersReducedEffects = () => Boolean(reducedMotionQuery?.matches);
 
+    const fontLoadCache = new Map();
+
+    function loadCustomFont(fontFamily) {
+        if (typeof fontFamily !== 'string') {
+            return Promise.resolve();
+        }
+
+        const normalizedFont = fontFamily.trim();
+        if (!normalizedFont) {
+            return Promise.resolve();
+        }
+
+        if (fontLoadCache.has(normalizedFont)) {
+            return fontLoadCache.get(normalizedFont);
+        }
+
+        const supportsFontLoadingApi =
+            typeof document !== 'undefined' && document.fonts && typeof document.fonts.load === 'function';
+
+        if (supportsFontLoadingApi && document.fonts.check(`1rem "${normalizedFont}"`)) {
+            const alreadyLoaded = Promise.resolve();
+            fontLoadCache.set(normalizedFont, alreadyLoaded);
+            return alreadyLoaded;
+        }
+
+        const fontPromises = [];
+
+        if (supportsFontLoadingApi) {
+            const fontQueries = [`1rem "${normalizedFont}"`, `700 1rem "${normalizedFont}"`];
+            for (const query of fontQueries) {
+                fontPromises.push(
+                    document.fonts
+                        .load(query)
+                        .catch(() => null)
+                );
+            }
+        }
+
+        const fontAssetSources = {
+            'Flight Time': 'assets/FlightTime.ttf'
+        };
+
+        const assetSource = fontAssetSources[normalizedFont];
+        if (assetSource && typeof window !== 'undefined' && typeof window.FontFace === 'function') {
+            const fontFace = new FontFace(normalizedFont, `url(${assetSource})`);
+            fontPromises.push(
+                fontFace
+                    .load()
+                    .then((loadedFace) => {
+                        document.fonts?.add?.(loadedFace);
+                    })
+                    .catch(() => null)
+            );
+        }
+
+        if (fontPromises.length === 0) {
+            const resolved = Promise.resolve();
+            fontLoadCache.set(normalizedFont, resolved);
+            return resolved;
+        }
+
+        const loadPromise = Promise.all(fontPromises).then(() => undefined);
+        fontLoadCache.set(normalizedFont, loadPromise);
+        return loadPromise;
+    }
+
     function enableHighQualitySmoothing(context) {
         if (!context) {
             return;


### PR DESCRIPTION
## Summary
- add a cached loadCustomFont helper so the game waits for the Flight Time font before initialization
- fall back gracefully when the browser does not support the font loading APIs

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d18bdb5bb88324b715ee2b0efcf766