### PR TITLE
Fix collect score fallback initialization

### DIFF
--- a/scripts/app.js
+++ b/scripts/app.js
@@ -6340,12 +6340,17 @@ document.addEventListener('DOMContentLoaded', () => {
             setPendingCharacter(initialCharacterProfile.id, { updateSummary: false });
         }
     }
+    const defaultCollectScore = 84;
     const baseCollectScoreRaw = config?.score?.collect;
     const baseCollectScore = Number.isFinite(Number(baseCollectScoreRaw))
         ? Math.max(1, Number(baseCollectScoreRaw))
         : defaultCollectScore;
+    const fallbackScoreConfig =
+        typeof baseGameConfig !== 'undefined' && baseGameConfig && isPlainObject(baseGameConfig.score)
+            ? baseGameConfig.score
+            : {};
     if (!config.score || !isPlainObject(config.score)) {
-        config.score = { ...baseGameConfig.score };
+        config.score = { ...fallbackScoreConfig };
     }
     config.score.collect = baseCollectScore;
 


### PR DESCRIPTION
## Summary
- add a default collect score fallback to prevent runtime reference errors
- guard the score fallback to avoid referencing an undefined base configuration

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68d1a0575f70832480eb76dabe91188d