### PR TITLE
Handle missing config before score setup

### DIFF
--- a/scripts/app.js
+++ b/scripts/app.js
@@ -6340,6 +6340,10 @@ document.addEventListener('DOMContentLoaded', () => {
             setPendingCharacter(initialCharacterProfile.id, { updateSummary: false });
         }
     }
+    if (!config || typeof config !== 'object') {
+        config = {};
+    }
+
     const defaultCollectScore = 84;
     const baseCollectScoreRaw = config?.score?.collect;
     const baseCollectScore = Number.isFinite(Number(baseCollectScoreRaw))


### PR DESCRIPTION
## Summary
- default the global configuration object to an empty object before applying score overrides

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d1a31ed7a88324bd87b8a7d22f09d5