### PR TITLE
Add missing difficulty preset application

### DIFF
--- a/scripts/app.js
+++ b/scripts/app.js
@@ -3726,6 +3726,31 @@ document.addEventListener('DOMContentLoaded', () => {
         return DIFFICULTY_PRESETS[normalized] ?? DIFFICULTY_PRESETS[DEFAULT_DIFFICULTY_ID];
     }
 
+    function applyDifficultyPreset(id, { announce = false } = {}) {
+        const preset = getDifficultyPreset(id);
+        const normalizedId = preset?.id ?? DEFAULT_DIFFICULTY_ID;
+        activeDifficultyPreset = normalizedId;
+
+        const baseConfig = applyOverrides(cloneConfig(baseGameConfig), gameplayOverrides);
+        const overrides = preset?.overrides;
+        const nextConfig = overrides ? applyOverrides(baseConfig, overrides) : baseConfig;
+
+        config = nextConfig;
+
+        if (typeof document !== 'undefined' && document.body) {
+            document.body.dataset.difficultyPreset = normalizedId;
+        }
+
+        if (announce && preset?.label) {
+            const message = preset.description
+                ? `${preset.label}: ${preset.description}`
+                : `${preset.label} difficulty engaged`;
+            console.info(`[difficulty] ${message}`);
+        }
+
+        return preset;
+    }
+
     const DEFAULT_SETTINGS = {
         masterVolume: typeof audioManager.getMasterVolume === 'function'
             ? audioManager.getMasterVolume()


### PR DESCRIPTION
## Summary
- add applyDifficultyPreset implementation to rebuild the runtime config when a difficulty is selected
- update the document body data attribute and log a message when difficulties change

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d1a7ed56d88324ab62d582376de477