### PR TITLE
Fix weapon loadout reset during game initialization

### DIFF
--- a/scripts/app.js
+++ b/scripts/app.js
@@ -8298,34 +8298,6 @@ document.addEventListener('DOMContentLoaded', () => {
         vy: 0
     };
 
-    function resetWeaponPatternState(weaponId) {
-        const weaponCollection = typeof weaponLoadouts !== 'undefined' && weaponLoadouts ? weaponLoadouts : null;
-        if (!weaponCollection || typeof weaponCollection !== 'object') {
-            return;
-        }
-
-        const idsToReset =
-            typeof weaponId === 'string' && weaponId.length > 0 ? [weaponId] : Object.keys(weaponCollection);
-
-        for (const id of idsToReset) {
-            const loadout = weaponCollection[id];
-            if (!loadout || typeof loadout !== 'object') {
-                continue;
-            }
-
-            if (typeof loadout.resetPatternState === 'function') {
-                loadout.resetPatternState();
-                continue;
-            }
-
-            if (typeof loadout.createPatternState === 'function') {
-                loadout.patternState = loadout.createPatternState();
-            } else if ('patternState' in loadout) {
-                loadout.patternState = undefined;
-            }
-        }
-    }
-
     function resetGame() {
         storyManager.prepareForRun();
         state.score = 0;
@@ -8367,7 +8339,29 @@ document.addEventListener('DOMContentLoaded', () => {
         hyperBeamState.wave = 0;
         hyperBeamState.sparkTimer = 0;
         hyperBeamState.bounds = null;
-        resetWeaponPatternState(activeWeaponId);
+        const weaponCollection =
+            typeof weaponLoadouts !== 'undefined' && weaponLoadouts ? weaponLoadouts : null;
+        if (weaponCollection && typeof weaponCollection === 'object') {
+            const idsToReset =
+                typeof activeWeaponId === 'string' && activeWeaponId.length > 0
+                    ? [activeWeaponId]
+                    : Object.keys(weaponCollection);
+
+            for (const id of idsToReset) {
+                const loadout = weaponCollection[id];
+                if (!loadout || typeof loadout !== 'object') {
+                    continue;
+                }
+
+                if (typeof loadout.resetPatternState === 'function') {
+                    loadout.resetPatternState();
+                } else if (typeof loadout.createPatternState === 'function') {
+                    loadout.patternState = loadout.createPatternState();
+                } else if ('patternState' in loadout) {
+                    loadout.patternState = undefined;
+                }
+            }
+        }
         player.x = viewport.width * 0.18;
         player.y = viewport.height * 0.5;
         player.vx = 0;


### PR DESCRIPTION
## Summary
- inline the weapon pattern reset logic directly in resetGame
- maintain loadout pattern initialization while avoiding undefined helper references

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d1caf590b483249d39bac129527819