### PR TITLE
Ensure player hub initializes after late script load

### DIFF
--- a/scripts/app.js
+++ b/scripts/app.js
@@ -629,7 +629,7 @@ function loadCustomFont(fontFamily) {
     return loadPromise;
 }
 
-document.addEventListener('DOMContentLoaded', () => {
+function initializeGame() {
     const GAMEPAD_CURSOR_HALF_SIZE = 11;
     // Reset onboarding flags whenever the game reinitializes. This ensures that
     // subsequent reloads (such as during development hot-reloads) don't carry
@@ -18571,5 +18571,11 @@ document.addEventListener('DOMContentLoaded', () => {
     createInitialStars();
     scheduleNextMeteorShower();
     requestAnimationFrame(gameLoop);
-});
+}
+
+if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', initializeGame, { once: true });
+} else {
+    initializeGame();
+}
 


### PR DESCRIPTION
## Summary
- wrap the game bootstrap logic in an `initializeGame` helper
- invoke initialization immediately when the DOM is already ready so player hub buttons stay interactive

## Testing
- not run (not provided)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690f75bac7e48324862823701013bb2c)